### PR TITLE
Refactor the normalizers to increase accuracy and minimize the use of pattern

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,9 @@
 # under the License.
 # 
 
+run:
+  tests: false
+
 linters-settings:
   govet:
     check-shadowing: true
@@ -37,6 +40,38 @@ linters-settings:
       fmt: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
+    ignore-words:
+      - analogue
+      - analyse
+      - artefact
+      - authorised
+      - calibre
+      - cancelled
+      - catalogue
+      - categorise
+      - centre
+      - emphasised
+      - favour
+      - favourite
+      - fulfil
+      - fulfilment
+      - initialise
+      - labelling
+      - labour
+      - licence
+      - maximise
+      - modelled
+      - modelling
+      - offence
+      - optimise
+      - organisation
+      - organise
+      - practise
+      - programme
+      - realise
+      - recognise
+      - signalling
+      - utilisation
   lll:
     line-length: 150
   goimports:
@@ -51,7 +86,7 @@ linters-settings:
     disabled-checks:
       - ifElseChain
   funlen:
-    lines: 150
+    lines: 100
     statements: 50
   whitespace:
     multi-if: false

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -38,10 +38,10 @@ header: # `header` section is configurations for source codes license header.
   # `pattern` is optional regexp if all the file headers are the same as `license` (linebreaks doesn't matter);
   # In the `pattern`, all punctuations should be removed unless they are part of the regex;
   pattern: |
-    Licensed to( the)? Apache Software Foundation \(ASF\) under one or more contributor
+    Licensed to the Apache Software Foundation under one or more contributor
     license agreements. See the NOTICE file distributed with
     this work for additional information regarding copyright
-    ownership. (Apache Software Foundation \(ASF\)|The ASF) licenses this file to you under
+    ownership. The Apache Software Foundation licenses this file to you under
     the Apache License, Version 2.0 \(the "License"\); you may
     not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/license-eye/commands/header/check.go
+++ b/license-eye/commands/header/check.go
@@ -19,6 +19,7 @@ package header
 
 import (
 	"github.com/apache/skywalking-eyes/license-eye/internal/logger"
+	"github.com/apache/skywalking-eyes/license-eye/pkg"
 	"github.com/apache/skywalking-eyes/license-eye/pkg/config"
 	"github.com/apache/skywalking-eyes/license-eye/pkg/header"
 
@@ -31,7 +32,7 @@ var CheckCommand = &cobra.Command{
 	Long:    "check command walks the specified paths recursively and checks if the specified files have the license header in the config file.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var config config.Config
-		var result header.Result
+		var result pkg.Result
 
 		if err := config.Parse(cfgFile); err != nil {
 			return err

--- a/license-eye/commands/header/fix.go
+++ b/license-eye/commands/header/fix.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/apache/skywalking-eyes/license-eye/internal/logger"
+	"github.com/apache/skywalking-eyes/license-eye/pkg"
 	"github.com/apache/skywalking-eyes/license-eye/pkg/config"
 	"github.com/apache/skywalking-eyes/license-eye/pkg/header"
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ var FixCommand = &cobra.Command{
 	Long:    "fix command walks the specified paths recursively and fix the license header if the specified files don't have the license header.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var config config.Config
-		var result header.Result
+		var result pkg.Result
 
 		if err := config.Parse(cfgFile); err != nil {
 			return err

--- a/license-eye/internal/logger/log.go
+++ b/license-eye/internal/logger/log.go
@@ -29,7 +29,7 @@ func init() {
 	if Log == nil {
 		Log = logrus.New()
 	}
-	Log.Level = logrus.InfoLevel
+	Log.Level = logrus.DebugLevel
 	Log.SetOutput(os.Stdout)
 	Log.SetFormatter(&logrus.TextFormatter{
 		DisableTimestamp:       true,

--- a/license-eye/pkg/header/check_test.go
+++ b/license-eye/pkg/header/check_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apache/skywalking-eyes/license-eye/pkg"
 	"gopkg.in/yaml.v3"
 )
 
@@ -48,7 +49,7 @@ func TestCheckFile(t *testing.T) {
 	type args struct {
 		name       string
 		file       string
-		result     *Result
+		result     *pkg.Result
 		wantErr    bool
 		hasFailure bool
 	}
@@ -64,7 +65,7 @@ func TestCheckFile(t *testing.T) {
 			cases = append(cases, args{
 				name:       file,
 				file:       file,
-				result:     &Result{},
+				result:     &pkg.Result{},
 				wantErr:    false,
 				hasFailure: false,
 			})
@@ -99,7 +100,7 @@ func TestCheckFileFailure(t *testing.T) {
 	type args struct {
 		name       string
 		file       string
-		result     *Result
+		result     *pkg.Result
 		wantErr    bool
 		hasFailure bool
 	}
@@ -115,7 +116,7 @@ func TestCheckFileFailure(t *testing.T) {
 			cases = append(cases, args{
 				name:       file,
 				file:       file,
-				result:     &Result{},
+				result:     &pkg.Result{},
 				wantErr:    false,
 				hasFailure: true,
 			})

--- a/license-eye/pkg/header/fix.go
+++ b/license-eye/pkg/header/fix.go
@@ -26,12 +26,13 @@ import (
 	"strings"
 
 	"github.com/apache/skywalking-eyes/license-eye/internal/logger"
+	"github.com/apache/skywalking-eyes/license-eye/pkg"
 	"github.com/apache/skywalking-eyes/license-eye/pkg/comments"
 )
 
 // Fix adds the configured license header to the given file.
-func Fix(file string, config *ConfigHeader, result *Result) error {
-	var r Result
+func Fix(file string, config *ConfigHeader, result *pkg.Result) error {
+	var r pkg.Result
 	if err := CheckFile(file, config, &r); err != nil || !r.HasFailure() {
 		logger.Log.Warnln("Try to fix a valid file, do nothing:", file)
 		return err
@@ -50,7 +51,7 @@ func Fix(file string, config *ConfigHeader, result *Result) error {
 	return nil
 }
 
-func InsertComment(file string, style *comments.CommentStyle, config *ConfigHeader, result *Result) error {
+func InsertComment(file string, style *comments.CommentStyle, config *ConfigHeader, result *pkg.Result) error {
 	stat, err := os.Stat(file)
 	if err != nil {
 		return err

--- a/license-eye/pkg/license/norm.go
+++ b/license-eye/pkg/license/norm.go
@@ -1,0 +1,171 @@
+//
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package license
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Normalizer func(string) string
+
+var (
+	// normalizers is a list of Normalizer that can be applied to the license text, yet doesn't change the license's
+	// meanings, according to the matching guide in https://spdx.dev/license-list/matching-guidelines.
+	// The order matters.
+	normalizers = []Normalizer{
+		OneLineNormalizer,
+		FlattenSpaceNormalizer,
+		SubstantiveTextsNormalizer,
+		strings.ToLower,
+		strings.TrimSpace,
+	}
+
+	// 6. Code Comment Indicators (https://spdx.dev/license-list/matching-guidelines.)
+	commentIndicators = []*regexp.Regexp{
+		regexp.MustCompile(`(?m)^\s*#+`),    // #
+		regexp.MustCompile(`(?m)^\s*//+`),   // //
+		regexp.MustCompile(`(?m)^\s*"""+`),  // """
+		regexp.MustCompile(`(?m)^\s*\(\*+`), // (*
+
+		regexp.MustCompile(`(?m)^\s*/\*+`), // /*
+		regexp.MustCompile(`(?m)^\s*\*+/`), //  */
+		regexp.MustCompile(`(?m)^\s*\*+`),  //  *
+
+		regexp.MustCompile(`(?m)^\s*<!--+`), // <!--
+		regexp.MustCompile(`(?m)^\s*--+>`),  // -->
+		regexp.MustCompile(`(?m)^\s*--+`),   // --
+		regexp.MustCompile(`(?m)^\s*~+`),    //   ~
+
+		regexp.MustCompile(`(?m)^\s*{-+`), // {-
+		regexp.MustCompile(`(?m)^\s*-}+`), // -}
+
+		regexp.MustCompile(`(?m)^\s*::`),   // ::
+		regexp.MustCompile(`(?m)^\s*@REM`), // @REM
+	}
+
+	flattenSpace = regexp.MustCompile(`\s+`)
+
+	substitutableTexts = []struct {
+		regex       *regexp.Regexp
+		replacement string
+	}{
+		{regexp.MustCompile(`(?i)\backnowledgement\b`), "acknowledgment"},
+		{regexp.MustCompile(`(?i)\banalog\b`), "analogue"},
+		{regexp.MustCompile(`(?i)\banalyze\b`), "analyse"},
+		{regexp.MustCompile(`(?i)\bartifact\b`), "artefact"},
+		{regexp.MustCompile(`(?i)\bauthorization\b`), "authorisation"},
+		{regexp.MustCompile(`(?i)\bauthorized\b`), "authorised"},
+		{regexp.MustCompile(`(?i)\bcaliber\b`), "calibre"},
+		{regexp.MustCompile(`(?i)\bcanceled\b`), "cancelled"},
+		{regexp.MustCompile(`(?i)\bcapitalizations\b`), "capitalisations"},
+		{regexp.MustCompile(`(?i)\bcatalog\b`), "catalogue"},
+		{regexp.MustCompile(`(?i)\bcategorize\b`), "categorise"},
+		{regexp.MustCompile(`(?i)\bcenter\b`), "centre"},
+		{regexp.MustCompile(`(?i)\bcopyright holder\b`), "copyright owner"},
+		{regexp.MustCompile(`(?i)\bemphasized\b`), "emphasised"},
+		{regexp.MustCompile(`(?i)\bfavor\b`), "favour"},
+		{regexp.MustCompile(`(?i)\bfavorite\b`), "favourite"},
+		{regexp.MustCompile(`(?i)\bfulfill\b`), "fulfil"},
+		{regexp.MustCompile(`(?i)\bfulfillment\b`), "fulfilment"},
+		{regexp.MustCompile(`(?i)\binitialize\b`), "initialise"},
+		{regexp.MustCompile(`(?i)\bjudgement\b`), "judgment"},
+		{regexp.MustCompile(`(?i)\blabeling\b`), "labelling"},
+		{regexp.MustCompile(`(?i)\blabor\b`), "labour"},
+		{regexp.MustCompile(`(?i)\blicense\b`), "licence"},
+		{regexp.MustCompile(`(?i)\bmaximize\b`), "maximise"},
+		{regexp.MustCompile(`(?i)\bmodeled\b`), "modelled"},
+		{regexp.MustCompile(`(?i)\bmodeling\b`), "modelling"},
+		{regexp.MustCompile(`(?i)\bnoncommercial\b`), "non-commercial"},
+		{regexp.MustCompile(`(?i)\boffense\b`), "offence"},
+		{regexp.MustCompile(`(?i)\boptimize\b`), "optimise"},
+		{regexp.MustCompile(`(?i)\borganization\b`), "organisation"},
+		{regexp.MustCompile(`(?i)\borganize\b`), "organise"},
+		{regexp.MustCompile(`(?i)\bpercent\b`), "per cent"},
+		{regexp.MustCompile(`(?i)\bpractice\b`), "practise"},
+		{regexp.MustCompile(`(?i)\bprogram\b`), "programme"},
+		{regexp.MustCompile(`(?i)\brealize\b`), "realise"},
+		{regexp.MustCompile(`(?i)\brecognize\b`), "recognise"},
+		{regexp.MustCompile(`(?i)\bsignaling\b`), "signalling"},
+		{regexp.MustCompile(`(?i)\bsublicense\b`), "sub-license"},
+		{regexp.MustCompile(`(?i)\bsub-license\b`), "sub license"},
+		{regexp.MustCompile(`(?i)\bsublicense\b`), "sub license"},
+		{regexp.MustCompile(`(?i)\butilization\b`), "utilisation"},
+		{regexp.MustCompile(`(?i)\bwhile\b`), "whilst"},
+		{regexp.MustCompile(`(?i)\bwilfull\b`), "wilful"},
+
+		{regexp.MustCompile(`©`), "Copyright "},
+		{regexp.MustCompile(`\(c\)`), "Copyright "},
+		{regexp.MustCompile(`\bhttps://`), "http://"},
+
+		{regexp.MustCompile(`(?i)\b(the )?Apache Software Foundation( \(ASF\))?`), "the ASF"},
+	}
+)
+
+// NormalizePattern applies a chain of Normalizers to the license pattern to make it cleaner for identification.
+func NormalizePattern(pattern string) string {
+	for _, normalize := range normalizers {
+		pattern = normalize(pattern)
+	}
+	return pattern
+}
+
+// NormalizeHeader applies a chain of Normalizers to the file header to make it cleaner for identification.
+func NormalizeHeader(header string) string {
+	ns := append([]Normalizer{CommentIndicatorNormalizer}, normalizers...)
+	for _, normalize := range ns {
+		header = normalize(header)
+	}
+	return header
+}
+
+// Normalize applies a chain of Normalizers to the license text to make it cleaner for identification.
+func Normalize(license string) string {
+	for _, normalize := range normalizers {
+		license = normalize(license)
+	}
+	return license
+}
+
+// OneLineNormalizer simply removes all line breaks to flatten the license text into one line.
+func OneLineNormalizer(text string) string {
+	return regexp.MustCompile("[\n\r]+").ReplaceAllString(text, " ")
+}
+
+// SubstantiveTextsNormalizer normalizes the license text by substituting some words that
+// doesn't change the meaning of the license.
+func SubstantiveTextsNormalizer(text string) string {
+	for _, s := range substitutableTexts {
+		text = s.regex.ReplaceAllString(text, s.replacement)
+	}
+	return text
+}
+
+// CommentIndicatorNormalizer trims the leading characters of comments, such as /*, <!--, --, (*, etc..
+func CommentIndicatorNormalizer(text string) string {
+	for _, leadingChars := range commentIndicators {
+		text = leadingChars.ReplaceAllString(text, "")
+	}
+	return text
+}
+
+// FlattenSpaceNormalizer flattens continuous spaces into a single space.
+func FlattenSpaceNormalizer(text string) string {
+	return flattenSpace.ReplaceAllString(text, " ")
+}

--- a/license-eye/pkg/license/norm_test.go
+++ b/license-eye/pkg/license/norm_test.go
@@ -1,0 +1,260 @@
+//
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package license
+
+import "testing"
+
+type input struct {
+	name string
+	text string
+	want string
+}
+
+func TestCommentLeadingCharsNormalizer(t *testing.T) {
+	want := ` Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+`
+	tests := []input{
+		{
+			name: "Jave",
+			want: want,
+			text: `
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+`,
+		},
+		{
+			name: "Python",
+			want: want,
+			text: `
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+`,
+		},
+		{
+			name: "XML",
+			want: want,
+			text: `
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+`,
+		},
+		{
+			name: "GoLang",
+			want: want,
+			text: `
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+`,
+		},
+		{
+			name: "SQL",
+			want: want,
+			text: `
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+`,
+		},
+		{
+			name: "BAT1",
+			want: want,
+			text: `
+:: Licensed to the Apache Software Foundation (ASF) under one or more
+:: contributor license agreements.  See the NOTICE file distributed with
+:: this work for additional information regarding copyright ownership.
+:: The ASF licenses this file to You under the Apache License, Version 2.0
+:: (the "License"); you may not use this file except in compliance with
+:: the License.  You may obtain a copy of the License at
+::
+::    http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+`,
+		},
+		{
+			name: "BAT2",
+			want: want,
+			text: `
+@REM Licensed to the Apache Software Foundation (ASF) under one or more
+@REM contributor license agreements.  See the NOTICE file distributed with
+@REM this work for additional information regarding copyright ownership.
+@REM The ASF licenses this file to You under the Apache License, Version 2.0
+@REM (the "License"); you may not use this file except in compliance with
+@REM the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+`,
+		},
+		{
+			name: "PythonTripleQuotes",
+			text: `
+"""
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+`,
+			want: `
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CommentIndicatorNormalizer(tt.text); got != tt.want {
+				t.Errorf("%v %v", len(got), len(tt.want))
+				t.Errorf("CommentIndicatorNormalizer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubstantiveTextsNormalizer(t *testing.T) {
+	tests := []input{
+		{
+			name: "ASF",
+			text: "Licensed to the Apache Software Foundation (ASF) under one or more",
+			want: "Licensed to the ASF under one or more",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubstantiveTextsNormalizer(tt.text); got != tt.want {
+				t.Errorf("SubstantiveTextsNormalizer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/license-eye/pkg/result.go
+++ b/license-eye/pkg/result.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-package header
+package pkg
 
 import (
 	"fmt"


### PR DESCRIPTION
With the normalizations, it's rare that `pattern` needs to be configured, this minimize the configurations and ease the usage 