### PR TITLE
Shape the quality-eye sub-directory for NGE2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Infra tools that are created and used by the SkyWalking Team.
 A full-featured license guard to check and fix license headers and dependencies' licenses.
 
 Read [the doc](license-eye/README.adoc) on how to use license-eye.
+
+## Quality Eye
+
+The next generation of end-to-end test framework that eyes on software quality.
+
+Read [the doc](quality-eye/README.md) on how the quality-eye is designed.

--- a/quality-eye/README.md
+++ b/quality-eye/README.md
@@ -1,0 +1,5 @@
+# Quality Eye - NGE2E
+
+NGE2E is the next generation End-to-End Testing framework that aims to help developers to set up, debug, and verify E2E tests with ease. It’s built based on the lessons learnt from tens of hundreds of test cases in the SkyWalking main repo.
+
+**[Design doc](https://skywalking.apache.org/blog/e2e-design/).**


### PR DESCRIPTION
This patch creates a sub-directory to host the new E2E framework codes, @fgksgf @Humbertzhang , let's host the codes here instead of in the CLI repo, they are independent after all.

@wu-sheng this also demonstrates how we organize different tools in this repo, we may have "release-eye" (checking gpg / sha512, etc.) in the future that stands alongside "license-eye", "quality-eye", etc.. Hope the structures make sense to you