### PR TITLE
Fix the inaccurate description of README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ header:
 
 ```bash
 $ git clone https://github.com/apache/skywalking-eyes
-$ cd skywalking-eyes/license-eye
+$ cd skywalking-eyes
 $ make build
 ```
 


### PR DESCRIPTION
Fix the inaccurate description of README.md, the `Compile from Source` in README.md is incorrect, and there is no license-eye directory in the skywalking-eyes directory.