### PR TITLE
defect: avoid crash when no comment style is found

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters-settings:
   golint:
     min-confidence: 0
   gocyclo:
-    min-complexity: 15
+    min-complexity: 20
   maligned:
     suggest-new: true
   dupl:

--- a/pkg/review/header.go
+++ b/pkg/review/header.go
@@ -144,7 +144,12 @@ func Header(result *header2.Result, config *config2.Config) error {
 				logger.Log.Warnln("Failed to get blob:", changedFile.GetFilename(), changedFile.GetSHA())
 				continue
 			}
-			header, err := header2.GenerateLicenseHeader(comments2.FileCommentStyle(changedFile.GetFilename()), &config.Header)
+			style := comments2.FileCommentStyle(changedFile.GetFilename())
+			if style == nil {
+				logger.Log.Warnln("Failed to determine the comment style of file:", changedFile.GetFilename())
+				continue
+			}
+			header, err := header2.GenerateLicenseHeader(style, &config.Header)
 			if err != nil {
 				logger.Log.Warnln("Failed to generate comment header:", changedFile.GetFilename())
 				continue


### PR DESCRIPTION
Discovered in https://github.com/apache/skywalking/pull/6467/checks?check_run_id=1994138869 (though there is naming issue in that PR)