### PR TITLE
Fix minor error

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,12 +37,11 @@ type Config struct {
 func (config *Config) Parse(file string) (err error) {
 	var bytes []byte
 
-	if file != "" {
-		logger.Log.Infoln("Loading configuration from file:", file)
+	// attempt to read configuration from specified file
+	logger.Log.Infoln("Loading configuration from file:", file)
 
-		if bytes, err = os.ReadFile(file); err != nil && !os.IsNotExist(err) {
-			return err
-		}
+	if bytes, err = os.ReadFile(file); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 
 	if os.IsNotExist(err) {

--- a/pkg/header/check.go
+++ b/pkg/header/check.go
@@ -45,7 +45,7 @@ func Check(config *ConfigHeader, result *Result) error {
 var seen = make(map[string]bool)
 
 func checkPattern(pattern string, result *Result, config *ConfigHeader) error {
-	paths, err := doublestar.Glob(pattern)
+	paths, err := glob(pattern)
 
 	if err != nil {
 		return err
@@ -65,10 +65,22 @@ func checkPattern(pattern string, result *Result, config *ConfigHeader) error {
 	return nil
 }
 
+func glob(pattern string) (matches []string, err error) {
+	if pattern == "." {
+		return doublestar.Glob("./")
+	}
+
+	return doublestar.Glob(pattern)
+}
+
 func checkPath(path string, result *Result, config *ConfigHeader) error {
 	defer func() { seen[path] = true }()
 
-	if yes, err := config.ShouldIgnore(path); yes || seen[path] || err != nil {
+	if seen[path] {
+		return nil
+	}
+
+	if yes, err := config.ShouldIgnore(path); yes || err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Reading an file named `""` will raise the `IsNotExist` error, so the conditional statement is unnecessary in `pkg/config/config.go`

The result should match whether the pattern is `.` or `./`.

Small improvement.