### PR TITLE
Fix typescript file license header fix to use SlashAsterisk instead of AngleBrackets

### DIFF
--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -6273,7 +6273,6 @@ XML:
     - ".sublime-snippet"
     - ".targets"
     - ".tml"
-    - ".ts"
     - ".tsx"
     - ".ui"
     - ".urdf"


### PR DESCRIPTION
The `.ts` (TypeScript) CommentStyle is already defined in Line 5819 of this file and should be `SlashAsterisk`.