### PR TITLE
 fix some program compatibility issues in Windows

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -21,15 +21,16 @@ package assets
 import (
 	"embed"
 	"io/fs"
+	"path/filepath"
 )
 
 //go:embed *
 var assets embed.FS
 
 func Asset(file string) ([]byte, error) {
-	return assets.ReadFile(file)
+	return assets.ReadFile(filepath.ToSlash(file))
 }
 
 func AssetDir(dir string) ([]fs.DirEntry, error) {
-	return assets.ReadDir(dir)
+	return assets.ReadDir(filepath.ToSlash(dir))
 }


### PR DESCRIPTION
The embeded file system `embed.FS` only takes the forward slash (`/`) as the path separator. However, the operating system path separator in Windows is the backward slash (`\`). We need to normalize the file path separator each time we use `embed.FS`.