### PR TITLE
Enhance NPM dependency resolver to resolve deprecated license styles

### DIFF
--- a/pkg/deps/npm.go
+++ b/pkg/deps/npm.go
@@ -224,7 +224,7 @@ func (resolver *NpmResolver) ResolvePkgFile(pkgFile string) (string, error) {
 		return lcs, nil
 	}
 
-	return "", fmt.Errorf("cannot parse the \"license\"/\"licenses\" field")
+	return "", fmt.Errorf(`cannot parse the "license"/"licenses" field`)
 }
 
 // ResolveLicenseField parses and validates the "license" field in package.json file

--- a/pkg/deps/npm.go
+++ b/pkg/deps/npm.go
@@ -249,19 +249,16 @@ func (resolver *NpmResolver) ResolveLicenseField(rawData []byte) (string, bool) 
 }
 
 // ResolveLicensesField parses and validates the "licenses" field in package.json file
-// Additionally, the output is converted into the SPDX license expression syntax version 2.0 string, like "(ISC OR GPL-3.0)"
+// Additionally, the output is converted into the SPDX license expression syntax version 2.0 string, like "ISC OR GPL-3.0"
 func (resolver *NpmResolver) ResolveLicensesField(licenses []Lcs) (string, bool) {
-	lcs := ""
+	var lcs []string
 	for _, l := range licenses {
-		lcs += l.Type + " "
+		lcs = append(lcs, l.Type)
 	}
-	lcs = strings.TrimSpace(lcs)
-	if lcs == "" {
+	if len(lcs) == 0 {
 		return "", false
 	}
-	lcs = strings.ReplaceAll(lcs, " ", " OR ")
-	lcs = fmt.Sprintf("(%s)", lcs)
-	return lcs, true
+	return strings.Join(lcs, " OR "), true
 }
 
 // ResolveLcsFile tries to find the license file to identify the license

--- a/pkg/deps/npm_test.go
+++ b/pkg/deps/npm_test.go
@@ -75,7 +75,7 @@ var TestData = []struct {
 }{
 	{lcsString, "ISC", false},
 	{lcsStruct, "ISC", false},
-	{lcss, "(MIT OR Apache-2.0)", false},
+	{lcss, "MIT OR Apache-2.0", false},
 	{lcsStringEmpty, "", true},
 	{lcsStructEmpty, "", true},
 	{lcssEmpty, "", true},

--- a/pkg/deps/npm_test.go
+++ b/pkg/deps/npm_test.go
@@ -1,0 +1,109 @@
+//
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package deps_test
+
+import (
+	"github.com/apache/skywalking-eyes/license-eye/pkg/deps"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var lcsString = `
+{
+  "license": "ISC"
+}`
+var lcsStruct = `
+{
+  "license": {
+    "type" : "ISC",
+    "url" : "https://opensource.org/licenses/ISC"
+  }
+}`
+var lcss = `
+{
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://www.opensource.org/licenses/mit-license.php"
+    },
+    {
+      "type": "Apache-2.0",
+      "url": "https://opensource.org/licenses/apache2.0.php"
+    }
+  ]
+}`
+var lcsStringEmpty = `
+{
+  "license": ""
+}`
+var lcsStructEmpty = `
+{
+  "license": {
+  }
+}`
+var lcssEmpty = `
+{
+  "licenses": [
+  ]
+}`
+var lcssInvalid = `
+{
+  "licenses": {
+  }
+}`
+
+var TestData = []struct {
+	data   string
+	result string
+	hasErr bool
+}{
+	{lcsString, "ISC", false},
+	{lcsStruct, "ISC", false},
+	{lcss, "(MIT OR Apache-2.0)", false},
+	{lcsStringEmpty, "", true},
+	{lcsStructEmpty, "", true},
+	{lcssEmpty, "", true},
+	{lcssInvalid, "", true},
+}
+
+func TestResolvePkgFile(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	resolver := new(deps.NpmResolver)
+	for _, data := range TestData {
+		f, err := ioutil.TempFile(dir, "*.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = f.WriteString(data.data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lcs, err := resolver.ResolvePkgFile(f.Name())
+		if lcs != data.result && (err != nil) == data.hasErr {
+			t.Fail()
+		}
+		_ = f.Close()
+	}
+}


### PR DESCRIPTION
This patch enhances the NPM dependency resolver to resolve deprecated license styles, which are like
```
{
  "license" : {
    "type" : "ISC",
    "url" : "https://opensource.org/licenses/ISC"
  }
}

{
  "licenses" : [
    {
      "type": "MIT",
      "url": "https://www.opensource.org/licenses/mit-license.php"
    },
    {
      "type": "Apache-2.0",
      "url": "https://opensource.org/licenses/apache2.0.php"
    }
  ]
}
```