### PR TITLE
add comment type to cython declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ make build
 ```bash
 bin/darwin/license-eye -c test/testdata/.licenserc_for_test_check.yaml header check
 
-INFO Loading configuration from file: test/testdata/.licenserc_for_test_check.yaml 
-INFO Totally checked 30 files, valid: 12, invalid: 12, ignored: 6, fixed: 0 
-ERROR the following files don't have a valid license header: 
+INFO Loading configuration from file: test/testdata/.licenserc_for_test_check.yaml
+INFO Totally checked 30 files, valid: 12, invalid: 12, ignored: 6, fixed: 0
+ERROR the following files don't have a valid license header:
 test/testdata/include_test/without_license/testcase.go
 test/testdata/include_test/without_license/testcase.graphql
 test/testdata/include_test/without_license/testcase.ini
@@ -95,7 +95,7 @@ test/testdata/include_test/without_license/testcase.sh
 test/testdata/include_test/without_license/testcase.yaml
 test/testdata/include_test/without_license/testcase.yml
 test/testdata/test-spdx-asf.yaml
-test/testdata/test-spdx.yaml 
+test/testdata/test-spdx.yaml
 exit status 1
 ```
 
@@ -105,7 +105,7 @@ exit status 1
 bin/darwin/license-eye -c test/testdata/.licenserc_for_test_fix.yaml header fix
 
 INFO Loading configuration from file: test/testdata/.licenserc_for_test_fix.yaml
-INFO Totally checked 20 files, valid: 10, invalid: 10, ignored: 0, fixed: 10 
+INFO Totally checked 20 files, valid: 10, invalid: 10, ignored: 0, fixed: 10
 ```
 
 #### Resolve Dependencies' licenses
@@ -159,23 +159,23 @@ the command will exit with status code 1 and fail the command.
 
 ```bash
 bin/darwin/license-eye -c test/testdata/.licenserc_for_test_check.yaml dep check
-INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
-INFO Loading configuration from file: .licenserc.yaml 
-WARNING Failed to resolve the license of <github.com/gogo/protobuf>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/kr/logfmt>: cannot find license file 
-WARNING Failed to resolve the license of <github.com/magiconair/properties>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/miekg/dns>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/pascaldekloe/goe>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/russross/blackfriday/v2>: cannot identify license content 
-WARNING Failed to resolve the license of <gopkg.in/check.v1>: cannot identify license content 
-ERROR the following licenses are incompatible with the main license: Apache-2.0 
+INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request
+INFO Loading configuration from file: .licenserc.yaml
+WARNING Failed to resolve the license of <github.com/gogo/protobuf>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/kr/logfmt>: cannot find license file
+WARNING Failed to resolve the license of <github.com/magiconair/properties>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/miekg/dns>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/pascaldekloe/goe>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/russross/blackfriday/v2>: cannot identify license content
+WARNING Failed to resolve the license of <gopkg.in/check.v1>: cannot identify license content
+ERROR the following licenses are incompatible with the main license: Apache-2.0
 License: Unknown Dependency: github.com/gogo/protobuf
 License: Unknown Dependency: github.com/kr/logfmt
 License: Unknown Dependency: github.com/magiconair/properties
 License: Unknown Dependency: github.com/miekg/dns
 License: Unknown Dependency: github.com/pascaldekloe/goe
 License: Unknown Dependency: github.com/russross/blackfriday/v2
-License: Unknown Dependency: gopkg.in/check.v1 
+License: Unknown Dependency: gopkg.in/check.v1
 exit status 1
 ```
 
@@ -277,7 +277,7 @@ The `header check` command theoretically supports all kinds of file types, while
     comment_style_id: SlashAsterisk
   ```
 
-- [assets/languages.yaml](assets/languages.yaml)
+- [assets/styles.yaml](assets/styles.yaml)
 
   ```yaml
   - id: SlashAsterisk     # (i)
@@ -293,7 +293,7 @@ The `header check` command theoretically supports all kinds of file types, while
 
 ## Technical Documentation
 
-- There is an [activity diagram](./docs/header_fix_logic.svg) explaining the implemented license header 
+- There is an [activity diagram](./docs/header_fix_logic.svg) explaining the implemented license header
   fixing mechanism in-depth. The diagram's source file can be found [here](./docs/header_fix_logic.plantuml).
 
 ## Contribution

--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -1097,6 +1097,7 @@ Cython:
   codemirror_mode: python
   codemirror_mime_type: text/x-cython
   language_id: 79
+  comment_style_id: Hashtag
 D:
   type: programming
   color: "#ba595e"

--- a/test/testdata/include_test/with_license/testcase.pyx
+++ b/test/testdata/include_test/with_license/testcase.pyx
@@ -1,0 +1,17 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# 

--- a/test/testdata/include_test/without_license/testcase.pyx
+++ b/test/testdata/include_test/without_license/testcase.pyx
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# Esse enim dolore adipisicing in cillum eiusmod excepteur quis nisi sit dolor anim anim id id nostrud nostrud tempor.
+# Elit sit enim cillum adipisicing non magna aute nostrud ullamco dolor dolore consequat ut ea occaecat veniam incididunt
+#  occaecat consectetur eiusmod sint eiusmod aute eu duis fugiat dolore in laboris enim eiusmod aliquip nisi aliqua irure 
+#  nulla proident ut ut aliqua et in ad deserunt nisi anim non dolore ut commodo excepteur ut eiusmod ex exercitation 
+#  in sunt cillum ullamco dolor magna ex proident elit in mollit incididunt excepteur dolor pariatur consectetur 
+#  exercitation qui ut cupidatat dolor do esse tempor commodo magna ad in duis voluptate est nisi in pariatur 
+#  duis mollit eiusmod est magna in velit aute anim ullamco nostrud adipisicing cupidatat non fugiat proident
+#   commodo minim sint minim pariatur nostrud sit mollit cillum dolor minim quis nisi id officia veniam 
+#   mollit tempor exercitation dolore duis cillum sunt esse nostrud deserunt amet ad quis reprehenderit 
+#   do in proident est incididunt voluptate et ullamco nisi dolore commodo mollit elit sint aute in occaecat 
+#   excepteur do pariatur laborum occaecat ad et nisi ut est in consequat commodo consectetur consequat ullamco m
+#   ollit aute dolor velit do deserunt eu velit reprehenderit incididunt commodo duis anim dolor velit nostrud eu 
+#   irure dolor mollit labore sunt consectetur ullamco sed consectetur sed sint consectetur eu fugiat amet nostrud 
+#   elit reprehenderit sunt ullamco fugiat eiusmod elit est est in duis quis occaecat proident aliquip adipisicing
+#    eu sint pariatur ullamco adipisicing cupidatat sed ut pariatur ut in amet deserunt laboris consectetur in 
+#    consectetur mollit voluptate magna ut ullamco pariatur proident esse commodo consectetur minim in do eu
+#     consequat ea eiusmod proident incididunt ut qui sunt consequat officia amet amet amet dolore fugiat ex.


### PR DESCRIPTION
Relates to #7552

Modified:

* `assets/languages.yaml`
    * Added `comment_style_id` to cython section
* `README.md`
    * Corrected link/description indicating `languages.yaml` instead of `styles.yaml`
    * Some whitespace trimming occurred (sorry)

Added test files for `*/pyx`:

```
test/testdata/include_test/with_license/testcase.pyx
test/testdata/include_test/without_license/testcase.pyx
```

Confirmed working via local docker build and testing against file indicated in https://github.com/apache/skywalking/issues/7552