### PR TITLE
Enable 'fix' on perl files

### DIFF
--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -4137,6 +4137,7 @@ Perl:
   aliases:
     - cperl
   language_id: 282
+  comment_style_id: Hashtag
 Pic:
   type: markup
   group: Roff

--- a/test/testdata/include_test/with_license/testcase.pl
+++ b/test/testdata/include_test/with_license/testcase.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#

--- a/test/testdata/include_test/without_license/testcase.pl
+++ b/test/testdata/include_test/without_license/testcase.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+# Esse enim dolore adipisicing in cillum eiusmod excepteur quis nisi sit dolor anim anim id id nostrud nostrud tempor.
+# Elit sit enim cillum adipisicing non magna aute nostrud ullamco dolor dolore consequat ut ea occaecat veniam incididunt
+#  occaecat consectetur eiusmod sint eiusmod aute eu duis fugiat dolore in laboris enim eiusmod aliquip nisi aliqua irure
+#  nulla proident ut ut aliqua et in ad deserunt nisi anim non dolore ut commodo excepteur ut eiusmod ex exercitation
+#  in sunt cillum ullamco dolor magna ex proident elit in mollit incididunt excepteur dolor pariatur consectetur
+#  exercitation qui ut cupidatat dolor do esse tempor commodo magna ad in duis voluptate est nisi in pariatur
+#  duis mollit eiusmod est magna in velit aute anim ullamco nostrud adipisicing cupidatat non fugiat proident
+#   commodo minim sint minim pariatur nostrud sit mollit cillum dolor minim quis nisi id officia veniam
+#   mollit tempor exercitation dolore duis cillum sunt esse nostrud deserunt amet ad quis reprehenderit
+#   do in proident est incididunt voluptate et ullamco nisi dolore commodo mollit elit sint aute in occaecat
+#   excepteur do pariatur laborum occaecat ad et nisi ut est in consequat commodo consectetur consequat ullamco m
+#   ollit aute dolor velit do deserunt eu velit reprehenderit incididunt commodo duis anim dolor velit nostrud eu
+#   irure dolor mollit labore sunt consectetur ullamco sed consectetur sed sint consectetur eu fugiat amet nostrud
+#   elit reprehenderit sunt ullamco fugiat eiusmod elit est est in duis quis occaecat proident aliquip adipisicing
+#    eu sint pariatur ullamco adipisicing cupidatat sed ut pariatur ut in amet deserunt laboris consectetur in
+#    consectetur mollit voluptate magna ut ullamco pariatur proident esse commodo consectetur minim in do eu
+#     consequat ea eiusmod proident incididunt ut qui sunt consequat officia amet amet amet dolore fugiat ex.


### PR DESCRIPTION
Adds correct comment type for perl files.  Local project uses `pl`, `pm` and `Makefile.PL` following "fix" all tests still function as expected.

ℹ️  would be incredibly useful to have the `latest` docker image reflect the state of the `main` branch (or an up to date release).