### PR TITLE
Fix file extension conflict between RenderScript and Rust

### DIFF
--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -4782,6 +4782,7 @@ RenderScript:
   tm_scope: none
   ace_mode: text
   language_id: 323
+  comment_style_id: DoubleSlash
 Rich Text Format:
   type: markup
   extensions:
@@ -4982,7 +4983,7 @@ Rust:
   codemirror_mode: rust
   codemirror_mime_type: text/x-rustsrc
   language_id: 327
-  comment_style_id: SlashAsterisk
+  comment_style_id: DoubleSlash
 SAS:
   type: programming
   color: "#B34936"


### PR DESCRIPTION
`comment_style_id` for Rust was added in #29, but currently, running `header fix` for Rust files does not work and displays `unsupported files: ...`.

The language configuration file contains two entries for the `.rs` file extension: RenderScript and Rust. `.rs` files end up matching RenderScript, which does not have a comment style. Locally, I fixed this for Rust by removing RenderScript from the language configuration file.

However, in this PR, I choose to set the command style for RenderScript to double slash, which is supported by both languages (and actually the [preferred](https://github.com/rust-lang/book/issues/693#issuecomment-301200629) style for Rust).