### PR TITLE
Remove .tsx from XML language extensions

### DIFF
--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -6279,7 +6279,6 @@ XML:
     - ".sublime-snippet"
     - ".targets"
     - ".tml"
-    - ".tsx"
     - ".ui"
     - ".urdf"
     - ".ux"


### PR DESCRIPTION
This is currently breaking my TypeScript codebase. I'm going to upstream this for y'all to land.