### PR TITLE
Add Comment Style for TypeScript language support

### DIFF
--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -6279,7 +6279,6 @@ XML:
     - ".sublime-snippet"
     - ".targets"
     - ".tml"
-    - ".tsx"
     - ".ui"
     - ".urdf"
     - ".ux"

--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -5610,6 +5610,7 @@ TSX:
   codemirror_mode: jsx
   codemirror_mime_type: text/jsx
   language_id: 94901924
+  comment_style_id: SlashAsterisk
 TXL:
   type: programming
   extensions:


### PR DESCRIPTION
I realized this was missing from my other PR. This is necessary to have the tool automatically add the License comment to the top of the file.