### PR TITLE
Speed up the initialization phase

### DIFF
--- a/pkg/license/identifier.go
+++ b/pkg/license/identifier.go
@@ -19,9 +19,11 @@ package license
 
 import (
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/apache/skywalking-eyes/license-eye/assets"
 	"github.com/apache/skywalking-eyes/license-eye/internal/logger"
@@ -37,23 +39,32 @@ var dualLicensePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)This project is covered by two different licenses: (?P<license>[^.]+)`),
 }
 
-var normalizedTemplates = make(map[string]string)
+var normalizedTemplates = sync.Map{}
 
 func init() {
+	wg := sync.WaitGroup{}
 	for _, dir := range templatesDirs {
 		files, err := assets.AssetDir(dir)
 		if err != nil {
 			logger.Log.Fatalln("Failed to read license template directory:", dir, err)
 		}
+		wg.Add(len(files))
 		for _, template := range files {
-			name := template.Name()
-			t, err := assets.Asset(filepath.Join(dir, name))
-			if err != nil {
-				logger.Log.Fatalln("Failed to read license template:", dir, err)
-			}
-			normalizedTemplates[dir+"/"+name] = Normalize(string(t))
+			go loadTemplate(&wg, dir, template)
 		}
 	}
+	wg.Wait()
+}
+
+func loadTemplate(wg *sync.WaitGroup, dir string, template fs.DirEntry) {
+	defer wg.Done()
+
+	name := template.Name()
+	t, err := assets.Asset(filepath.Join(dir, name))
+	if err != nil {
+		logger.Log.Fatalln("Failed to read license template:", dir, err)
+	}
+	normalizedTemplates.Store(dir+"/"+name, Normalize(string(t)))
 }
 
 // Identify identifies the Spdx ID of the given license content
@@ -68,17 +79,26 @@ func Identify(pkgPath, content string) (string, error) {
 	}
 
 	content = Normalize(content)
+	logger.Log.Debugf("Normalized content for %+v:\n%+v\n", pkgPath, content)
 
-	for name, license := range normalizedTemplates {
+	result := make(chan string, 1)
+	normalizedTemplates.Range(func(key, value interface{}) bool {
+		name := key.(string)
+		license := value.(string)
+
 		// Should not use `Contains` as a root LICENSE file may include other licenses the project uses,
 		// `Contains` would identify the last one license as the project's license.
 		if strings.HasPrefix(content, license) {
 			name = filepath.Base(name)
-			return strings.TrimSuffix(name, filepath.Ext(name)), nil
+			result <- strings.TrimSuffix(name, filepath.Ext(name))
+			return false
 		}
+		return true
+	})
+	select {
+	case license := <-result:
+		return license, nil
+	default:
+		return "", fmt.Errorf("cannot identify license content")
 	}
-
-	logger.Log.Debugf("Normalized content for %+v:\n%+v\n", pkgPath, content)
-
-	return "", fmt.Errorf("cannot identify license content")
 }


### PR DESCRIPTION
We have many license template files to load at initialization phase, this speeds up the initialization phase from 8s to 2s

```
pwd                                                        
/Users/kezhenxu94/workspace/skywalking-infra-e2e
```

# Before                                                   

```
time ~/workspace/skywalking-eyes/bin/darwin/license-eye h c
INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
INFO Loading configuration from file: .licenserc.yaml 
INFO Totally checked 2336 files, valid: 59, invalid: 0, ignored: 2277, fixed: 0 

================
CPU	108%
user	8.451
system	0.351
total	8.146

time ~/workspace/skywalking-eyes/bin/darwin/license-eye h c
INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
INFO Loading configuration from file: .licenserc.yaml 
INFO Totally checked 2336 files, valid: 59, invalid: 0, ignored: 2277, fixed: 0 

================
CPU	107%
user	8.380
system	0.337
total	8.086

time ~/workspace/skywalking-eyes/bin/darwin/license-eye h c
INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
INFO Loading configuration from file: .licenserc.yaml 
INFO Totally checked 2336 files, valid: 59, invalid: 0, ignored: 2277, fixed: 0 

================
CPU	107%
user	8.921
system	0.357
total	8.661
```

# After

```
time ~/workspace/skywalking-eyes/bin/darwin/license-eye h c
INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
INFO Loading configuration from file: .licenserc.yaml 
INFO Totally checked 2336 files, valid: 59, invalid: 0, ignored: 2277, fixed: 0 

================
CPU	927%
user	17.638
system	0.511
total	1.957

time ~/workspace/skywalking-eyes/bin/darwin/license-eye h c
INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
INFO Loading configuration from file: .licenserc.yaml 
INFO Totally checked 2336 files, valid: 59, invalid: 0, ignored: 2277, fixed: 0 

================
CPU	1076%
user	18.164
system	0.517
total	1.736

time ~/workspace/skywalking-eyes/bin/darwin/license-eye h c
INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request 
INFO Loading configuration from file: .licenserc.yaml 
INFO Totally checked 2336 files, valid: 59, invalid: 0, ignored: 2277, fixed: 0 

================
CPU	994%
user	17.888
system	0.492
total	1.847

```