### PR TITLE
Added .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: fix-license
+    name: fix-license
+    entry: license-eye header fix
+    language: golang
+    description: Add license headers to files missing them


### PR DESCRIPTION
This addition allows users of the [pre-commit](https://pre-commit.com/) Git hook management tool to use Skywalking Eyes' `license-eyes header fix` command to automate fixing their license headers at regular points in the development lifecycle.