### PR TITLE
Adds an option to the action to run in "fix" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To use License-Eye in GitHub Actions, add a step in your GitHub workflow.
       # log: debug # optional: set the log level. The default value is `info`.
       # config: .licenserc.yaml # optional: set the config file. The default value is `.licenserc.yaml`.
       # token: # optional: the token that license eye uses when it needs to comment on the pull request. Set to empty ("") to disable commenting on pull request. The default value is ${{ github.token }}
+      # mode: # optional: Which mode License Eye should be run in. Choices are `check` or `fix`. The default value is `check`.
 ```
 
 Add a `.licenserc.yaml` in the root of your project, for Apache Software Foundation projects, the following configuration should be enough.
@@ -142,13 +143,13 @@ license-eye -c test/testdata/.licenserc_for_test_check.yaml dep resolve -o ./dep
 ```
 INFO GITHUB_TOKEN is not set, license-eye won't comment on the pull request
 INFO Loading configuration from file: test/testdata/.licenserc_for_test_check.yaml
-WARNING Failed to resolve the license of <github.com/gogo/protobuf>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/kr/logfmt>: cannot find license file 
-WARNING Failed to resolve the license of <github.com/magiconair/properties>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/miekg/dns>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/pascaldekloe/goe>: cannot identify license content 
-WARNING Failed to resolve the license of <github.com/russross/blackfriday/v2>: cannot identify license content 
-WARNING Failed to resolve the license of <gopkg.in/check.v1>: cannot identify license content 
+WARNING Failed to resolve the license of <github.com/gogo/protobuf>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/kr/logfmt>: cannot find license file
+WARNING Failed to resolve the license of <github.com/magiconair/properties>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/miekg/dns>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/pascaldekloe/goe>: cannot identify license content
+WARNING Failed to resolve the license of <github.com/russross/blackfriday/v2>: cannot identify license content
+WARNING Failed to resolve the license of <gopkg.in/check.v1>: cannot identify license content
 Dependency                                         |        License |                              Version
 -------------------------------------------------- | -------------- | ------------------------------------
 cloud.google.com/go                                |     Apache-2.0 |                              v0.46.3

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use License-Eye in GitHub Actions, add a step in your GitHub workflow.
       # log: debug # optional: set the log level. The default value is `info`.
       # config: .licenserc.yaml # optional: set the config file. The default value is `.licenserc.yaml`.
       # token: # optional: the token that license eye uses when it needs to comment on the pull request. Set to empty ("") to disable commenting on pull request. The default value is ${{ github.token }}
-      # mode: # optional: Which mode License Eye should be run in. Choices are `check` or `fix`. The default value is `check`.
+      # mode: # optional: Which mode License-Eye should be run in. Choices are `check` or `fix`. The default value is `check`.
 ```
 
 Add a `.licenserc.yaml` in the root of your project, for Apache Software Foundation projects, the following configuration should be enough.
@@ -43,6 +43,33 @@ header:
 ```
 
 **NOTE**: The full configurations can be found in [the configuration section](#configurations).
+
+#### Using the Action in Fix Mode
+
+By default the action runs License-Eye in check mode, which will raise an error
+if any of the processed files are missing license headers. If `mode` is set to
+`fix`, the action will instead apply the license header to any processed file
+that is missing a license header. The fixed files can then be pushed back to the
+pull request using another GitHub action. For example:
+
+```yaml
+- name: Check License Header
+  uses: apache/skywalking-eyes@main
+    with:
+      mode: fix
+- name: Apply Changes
+  uses: EndBug/add-and-commit@v4
+    with:
+      author_name: License Bot
+      author_email: license_bot@github.com
+      message: 'Automatic application of license header'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Note**: The exit code of fix mode is always 0 and can not be used to block CI
+status. Consider running the action in check mode if you would like CI to fail
+when a file is missing a license header.
 
 ### Docker Image
 

--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,8 @@ inputs:
     default: ${{ github.token }}
   mode:
     description: |
-      Which mode License Eye should be run in. Choices are "check" or "fix".
-      Default is "check".
+      Which mode License Eye should be run in. Choices are `check` or `fix`. The
+      default value is `check`.
     required: false
     default: check
 runs:

--- a/action.yml
+++ b/action.yml
@@ -5,16 +5,16 @@
 # the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# 
+#
 name: License Eye
 description: A full-featured license tool to check and fix license headers and dependencies' licenses.
 branding:
@@ -35,6 +35,12 @@ inputs:
       Set to empty ("") to disable commenting on pull request.
     required: false
     default: ${{ github.token }}
+  mode:
+    description: |
+      Which mode License Eye should be run in. Choices are "check" or "fix".
+      Default is "check".
+    required: false
+    default: check
 runs:
   using: docker
   image: Dockerfile
@@ -46,4 +52,4 @@ runs:
     - -c
     - ${{ inputs.config }}
     - header
-    - check
+    - ${{ inputs.mode }}


### PR DESCRIPTION
This PR is a small change which adds an additional, optional, input to the action called `mode`. My goal with this change is to make it so CI pipelines can automatically apply the licenses to PRs which lack them (applying the changes would be handled by a different action like [this one](https://github.com/EndBug/add-and-commit)). I looked around and did not see any mention of such functionality; apologies if I missed it.

Some additional notes:

- `mode` can take one of two values: `check` or `fix`. I set the default to `check` to preserve existing behavior.
- I have also updated the README with the new input description. 
- I see from the diff that my IDE removed some trailing spaces; if you really want those back I can redo the changes with vim or something
- I have tested that this works as intended with one of my own repositories; if you want proper unit tests I will need guidance/help on how to go about doing that.