### PR TITLE
Add MPL-2.0 header template

### DIFF
--- a/assets/header-templates/MPL-2.0.txt
+++ b/assets/header-templates/MPL-2.0.txt
@@ -1,0 +1,3 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Hi there, thanks for this great project! I am using the MPL in some places, and so would love built-in support for it. It's really nice that it was so easy to use a `content` block to get started, but I figured upstreaming this would be nice :) 

I am not sure if I should be adding a test or anything, happy to make any modifications you'd like. I did verify that this works by running my branch against a sample codebase, you can see that result here: https://github.com/steveklabnik/ci-license-test/pull/4