### PR TITLE
Lock version of golangci-lint to 1.43.0. And fix lint issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all: clean lint license test build
 
 .PHONY: lint
 lint:
-	$(GO_LINT) version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin
+	$(GO_LINT) version || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin v1.43.0
 	$(GO_LINT) run -v ./...
 
 .PHONY: fix-lint

--- a/commands/deps_resolve.go
+++ b/commands/deps_resolve.go
@@ -52,7 +52,7 @@ var DepsResolveCommand = &cobra.Command{
 			return err
 		}
 		outDir = absPath
-		if err := os.MkdirAll(outDir, 0700); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(outDir, 0o700); err != nil && !os.IsExist(err) {
 			return err
 		}
 		return nil

--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -105,7 +104,7 @@ func (resolver *GoModResolver) ResolvePackageLicense(module *packages.Module, re
 
 	for {
 		logger.Log.Debugf("Directory of %+v is %+v", module.Path, dir)
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			return err
 		}
@@ -114,7 +113,7 @@ func (resolver *GoModResolver) ResolvePackageLicense(module *packages.Module, re
 				continue
 			}
 			licenseFilePath := filepath.Join(dir, info.Name())
-			content, err := ioutil.ReadFile(licenseFilePath)
+			content, err := os.ReadFile(licenseFilePath)
 			if err != nil {
 				return err
 			}

--- a/pkg/deps/npm.go
+++ b/pkg/deps/npm.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,7 +260,7 @@ func (resolver *NpmResolver) ResolveLicensesField(licenses []Lcs) (string, bool)
 
 // ResolveLcsFile tries to find the license file to identify the license
 func (resolver *NpmResolver) ResolveLcsFile(result *Result, pkgPath string) error {
-	depFiles, err := ioutil.ReadDir(pkgPath)
+	depFiles, err := os.ReadDir(pkgPath)
 	if err != nil {
 		return err
 	}
@@ -271,7 +270,7 @@ func (resolver *NpmResolver) ResolveLcsFile(result *Result, pkgPath string) erro
 		}
 		licenseFilePath := filepath.Join(pkgPath, info.Name())
 		result.LicenseFilePath = licenseFilePath
-		content, err := ioutil.ReadFile(licenseFilePath)
+		content, err := os.ReadFile(licenseFilePath)
 		if err != nil {
 			return err
 		}
@@ -291,7 +290,7 @@ func (resolver *NpmResolver) ResolveLcsFile(result *Result, pkgPath string) erro
 
 // ParsePkgFile parses the content of the package file
 func (resolver *NpmResolver) ParsePkgFile(pkgFile string) (*Package, error) {
-	content, err := ioutil.ReadFile(pkgFile)
+	content, err := os.ReadFile(pkgFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/header/check.go
+++ b/pkg/header/check.go
@@ -18,7 +18,6 @@
 package header
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -120,7 +119,7 @@ func CheckFile(file string, config *ConfigHeader, result *Result) error {
 
 	logger.Log.Debugln("Checking file:", file)
 
-	bs, err := ioutil.ReadFile(file)
+	bs, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/pkg/header/fix.go
+++ b/pkg/header/fix.go
@@ -20,7 +20,6 @@ package header
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"regexp"
@@ -53,7 +52,7 @@ func InsertComment(file string, style *comments.CommentStyle, config *ConfigHead
 		return err
 	}
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -65,7 +64,7 @@ func InsertComment(file string, style *comments.CommentStyle, config *ConfigHead
 
 	content = rewriteContent(style, content, licenseHeader)
 
-	if err := ioutil.WriteFile(file, content, stat.Mode()); err != nil {
+	if err := os.WriteFile(file, content, stat.Mode()); err != nil {
 		return err
 	}
 

--- a/pkg/review/header.go
+++ b/pkg/review/header.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -291,7 +290,7 @@ func GetSha() (string, error) {
 	if filepath == "" {
 		return "", fmt.Errorf("failed to get event path")
 	}
-	content, err := ioutil.ReadFile(filepath)
+	content, err := os.ReadFile(filepath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Noticed the lint error on https://github.com/apache/skywalking-eyes/pull/87, it is caused by we were using the latest lint, but the rules change from time to time.

Lock it to v1.43.0 this time, and fix the gap between the last build and v1.43.0