### PR TITLE
Add comment style for HCL (Terraform)

### DIFF
--- a/assets/languages.yaml
+++ b/assets/languages.yaml
@@ -2055,6 +2055,7 @@ HCL:
   codemirror_mime_type: text/x-ruby
   tm_scope: source.terraform
   language_id: 144
+  comment_style_id: Hashtag
 HLSL:
   type: programming
   extensions:


### PR DESCRIPTION
Add comment style for HCL (Terraform) to enable `header fix` support

https://www.terraform.io/language/syntax/configuration#comments