### PR TITLE
Fix license check in go library testify

### DIFF
--- a/pkg/license/norm.go
+++ b/pkg/license/norm.go
@@ -255,6 +255,11 @@ var (
 			regexp.MustCompile(`(?im)^\s*.+ is distributed under the Simplified BSD License\:?$`),
 			"",
 		},
+		// Please consider promoting this project if you find it useful.
+		{
+			regexp.MustCompile(`(?im)^\s*Please consider promoting this project if you find it useful\.?$`),
+			"",
+		},
 
 		// This should be the last one processor
 		{


### PR DESCRIPTION
I use the `logrus` library in the go and it's dependent on the old version of the testify library. After I run `dep check`, the license of this library could not analyze.

Here is the `LICENSE` file link: https://raw.githubusercontent.com/stretchr/testify/v1.2.2/LICENSE