### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/deps/jar_test.go
+++ b/pkg/deps/jar_test.go
@@ -86,14 +86,7 @@ func TestResolveJar(t *testing.T) {
 
 	resolver := new(deps.JarResolver)
 
-	path, err := tmpDir()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer destroyTmpDir(t, path)
-
-	pomFile := filepath.Join(path, "pom.xml")
+	pomFile := filepath.Join(t.TempDir(), "pom.xml")
 
 	for _, test := range []struct {
 		pomContent string

--- a/pkg/deps/maven_test.go
+++ b/pkg/deps/maven_test.go
@@ -20,7 +20,6 @@ package deps_test
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,26 +64,6 @@ func dumpPomFile(fileName, content string) error {
 	return nil
 }
 
-func tmpDir() (string, error) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		return "", err
-	}
-	return dir, nil
-}
-
-func destroyTmpDir(t *testing.T, dir string) {
-	if dir == "" {
-		t.Errorf("the temporary directory does not exist")
-		return
-	}
-
-	err := os.RemoveAll(dir)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestResolveMaven(t *testing.T) {
 	if _, err := exec.Command("mvn", "--version").Output(); err != nil {
 		logger.Log.Warnf("Failed to find mvn, the test `TestResolveMaven` was skipped")
@@ -93,14 +72,7 @@ func TestResolveMaven(t *testing.T) {
 
 	resolver := new(deps.MavenPomResolver)
 
-	path, err := tmpDir()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer destroyTmpDir(t, path)
-
-	pomFile := filepath.Join(path, "pom.xml")
+	pomFile := filepath.Join(t.TempDir(), "pom.xml")
 
 	for _, test := range []struct {
 		pomContent string

--- a/pkg/deps/npm_test.go
+++ b/pkg/deps/npm_test.go
@@ -19,7 +19,6 @@ package deps_test
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/apache/skywalking-eyes/pkg/deps"
@@ -84,11 +83,7 @@ var TestData = []struct {
 }
 
 func TestResolvePkgFile(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	resolver := new(deps.NpmResolver)
 	for _, data := range TestData {
 		result := &deps.Result{}


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir