### PR TITLE
dep: short circuit if user declare dep license

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -27,9 +27,9 @@ header: # `header` section is configurations for source codes license header.
       to you under the Apache License, Version 2.0 (the
       "License"); you may not use this file except in compliance
       with the License.  You may obtain a copy of the License at
-    
+
           http://www.apache.org/licenses/LICENSE-2.0
-      
+
       Unless required by applicable law or agreed to in writing,
       software distributed under the License is distributed on an
       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,9 +46,9 @@ header: # `header` section is configurations for source codes license header.
       to you under the Apache License, Version 2.0 (the
       "License"); you may not use this file except in compliance
       with the License.  You may obtain a copy of the License at
-    
+
           http://www.apache.org/licenses/LICENSE-2.0
-      
+
       Unless required by applicable law or agreed to in writing,
       software distributed under the License is distributed on an
       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/README.md
+++ b/README.md
@@ -764,7 +764,7 @@ header: # <1>
 dependency: # <15>
   files: # <16>
     - go.mod
-  license: # <17>
+  licenses: # <17>
     - name: dependency-name # <18>
       version: dependency-version # <19>
       license: Apache-2.0 # <20>

--- a/pkg/deps/jar.go
+++ b/pkg/deps/jar.go
@@ -37,7 +37,7 @@ func (resolver *JarResolver) CanResolve(jarFile string) bool {
 	return filepath.Ext(jarFile) == ".jar"
 }
 
-func (resolver *JarResolver) Resolve(jarFile string, licenses []*ConfigDepLicense, report *Report) error {
+func (resolver *JarResolver) Resolve(jarFile string, report *Report) error {
 	state := NotFound
 	if err := resolver.ResolveJar(&state, jarFile, Unknown, report); err != nil {
 		dep := filepath.Base(jarFile)
@@ -76,7 +76,7 @@ func (resolver *JarResolver) ResolveJar(state *State, jarFile, version string, r
 				return err
 			}
 
-			return resolver.IdentifyLicense(jarFile, dep, buf.String(), version, nil, report)
+			return resolver.IdentifyLicense(jarFile, dep, buf.String(), version, report)
 		}
 	}
 
@@ -122,23 +122,17 @@ func (resolver *JarResolver) ReadFileFromZip(archiveFile *zip.File) (*bytes.Buff
 	return buf, nil
 }
 
-func (resolver *JarResolver) IdentifyLicense(path, dep, content, version string, declareLicense *ConfigDepLicense, report *Report) error {
-	var licenseID string
-	if declareLicense != nil {
-		licenseID = declareLicense.License
-	} else {
-		identifier, err := license.Identify(path, content)
-		if err != nil {
-			return err
-		}
-		licenseID = identifier
+func (resolver *JarResolver) IdentifyLicense(path, dep, content, version string, report *Report) error {
+	identifier, err := license.Identify(path, content)
+	if err != nil {
+		return err
 	}
 
 	report.Resolve(&Result{
 		Dependency:      dep,
 		LicenseFilePath: path,
 		LicenseContent:  content,
-		LicenseSpdxID:   licenseID,
+		LicenseSpdxID:   identifier,
 		Version:         version,
 	})
 	return nil

--- a/pkg/deps/jar_test.go
+++ b/pkg/deps/jar_test.go
@@ -96,11 +96,11 @@ func TestResolveJar(t *testing.T) {
 	<project xmlns="http://maven.apache.org/POM/4.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 		<modelVersion>4.0.0</modelVersion>
-	
+
 		<groupId>apache</groupId>
 		<artifactId>skywalking-eyes</artifactId>
 		<version>1.0</version>
-	
+
 		<dependencies>
 			<!-- https://mvnrepository.com/artifact/junit/junit -->
 			<dependency>
@@ -132,7 +132,7 @@ func TestResolveJar(t *testing.T) {
 		report := deps.Report{}
 		for _, jar := range jars {
 			if resolver.CanResolve(jar) {
-				if err := resolver.Resolve(jar, nil, &report); err != nil {
+				if err := resolver.Resolve(jar, &report); err != nil {
 					t.Error(err)
 					return
 				}


### PR DESCRIPTION
This is also a bug that when there is no LICENSE file in dependency folder, the `licenses` doesn't work.