### PR TITLE
[docs] Fix the indents issue in the action demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ pull request using another GitHub action. For example:
 ```yaml
 - name: Check License Header
   uses: apache/skywalking-eyes@main
-    with:
-      mode: fix
+  with:
+    mode: fix
 - name: Apply Changes
   uses: EndBug/add-and-commit@v4
-    with:
-      author_name: License Bot
-      author_email: license_bot@github.com
-      message: 'Automatic application of license header'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    author_name: License Bot
+    author_email: license_bot@github.com
+    message: 'Automatic application of license header'
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 **Note**: The exit code of fix mode is always 0 and can not be used to block CI


### PR DESCRIPTION
# Motivation
If users use this demo as a copy, the indents issue in the action demo will lead to the failure of action.

<img width="564" alt="image" src="https://user-images.githubusercontent.com/93108425/169087794-ac603409-0285-4cf6-acea-5d5e0716a998.png">

# Modification
According to the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-7), the `with` has the same indents with `uses`, so just remove the extra indents in the demo.
<img width="788" alt="image" src="https://user-images.githubusercontent.com/93108425/169088541-31738122-797e-4894-99ad-c4365b5820bc.png">
