### PR TITLE
Add support for multiple licenses in the header config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,16 @@ dependency: # <15>
       version: dependency-version # the same format as <19>
 ```
 
-1. The `header` section is configurations for source codes license header.
+1. The `header` section is configurations for source codes license header. If you have mutliple modules or packages in your project that have differing licenses, this section may contain a list of licenses:
+```yaml
+header:
+  - license:
+    spdx-id: Apache-2.0
+    path: "/path/to/module/a"
+  - license:
+    spdx-id: MPL-2.0
+    path: "/path/to/module/b"
+```
 2. The [SPDX ID](https://spdx.org/licenses/) of the license, it’s convenient when your license is standard SPDX license, so that you can simply specify this identifier without copying the whole license `content` or `pattern`. This will be used as the content when `fix` command needs to insert a license header.
 3. The copyright owner to replace the `[owner]` in the `SPDX-ID` license template.
 4. If you are not using the standard license text, you can paste your license text here, this will be used as the content when `fix` command needs to insert a license header, if both `license` and `SPDX-ID` are specified, `license` wins.

--- a/commands/deps_resolve.go
+++ b/commands/deps_resolve.go
@@ -77,7 +77,8 @@ var DepsResolveCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		report := deps.Report{}
 
-		if err := deps.Resolve(&Config.Deps, &report); err != nil {
+		configDeps := Config.Dependencies()
+		if err := deps.Resolve(configDeps, &report); err != nil {
 			return err
 		}
 
@@ -132,7 +133,12 @@ func writeSummary(rep *deps.Report) error {
 		return err
 	}
 	defer file.Close()
-	summary, err := deps.GenerateSummary(summaryTpl, &Config.Header, rep)
+
+	headers := Config.Headers()
+	if len(headers) > 1 {
+		return fmt.Errorf("unable to write summary as multiple licenses were provided in configuration")
+	}
+	summary, err := deps.GenerateSummary(summaryTpl, headers[0], rep)
 	if err != nil {
 		return err
 	}

--- a/commands/header_fix.go
+++ b/commands/header_fix.go
@@ -32,30 +32,30 @@ var FixCommand = &cobra.Command{
 	Aliases: []string{"f"},
 	Long:    "fix command walks the specified paths recursively and fix the license header if the specified files don't have the license header.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var result header.Result
 		var errors []string
-		var files []string
+		for _, h := range Config.Headers() {
+			var result header.Result
+			var files []string
 
-		if len(args) > 0 {
-			files = args
-		} else if err := header.Check(&Config.Header, &result); err != nil {
-			return err
-		} else {
-			files = result.Failure
-		}
-
-		for _, file := range files {
-			if err := header.Fix(file, &Config.Header, &result); err != nil {
-				errors = append(errors, err.Error())
+			if len(args) > 0 {
+				files = args
+			} else if err := header.Check(h, &result); err != nil {
+				return err
+			} else {
+				files = result.Failure
 			}
+
+			for _, file := range files {
+				if err := header.Fix(file, h, &result); err != nil {
+					errors = append(errors, err.Error())
+				}
+			}
+
+			logger.Log.Infoln(result.String())
 		}
-
-		logger.Log.Infoln(result.String())
-
 		if len(errors) > 0 {
 			return fmt.Errorf("%s", strings.Join(errors, "\n"))
 		}
-
 		return nil
 	},
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -44,7 +44,8 @@ var root = &cobra.Command{
 		}
 		logger.Log.SetLevel(level)
 
-		return Config.Parse(configFile)
+		Config, err = config.NewConfigFromFile(configFile)
+		return err
 	},
 	Version: version,
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,37 +28,97 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type Config struct {
+type V1 struct {
 	Header header.ConfigHeader `yaml:"header"`
 	Deps   deps.ConfigDeps     `yaml:"dependency"`
 }
 
-// Parse reads and parses the header check configurations in config file.
-func (config *Config) Parse(file string) (err error) {
-	var bytes []byte
-
-	// attempt to read configuration from specified file
-	logger.Log.Infoln("Loading configuration from file:", file)
-
-	if bytes, err = os.ReadFile(file); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if os.IsNotExist(err) {
-		logger.Log.Infof("Config file %s does not exist, using the default config", file)
-
-		if bytes, err = assets.Asset("default-config.yaml"); err != nil {
-			return err
-		}
-	}
-
-	if err := yaml.Unmarshal(bytes, config); err != nil {
-		return err
+func ParseV1(filename string, bytes []byte) (*V1, error) {
+	var config V1
+	if err := yaml.Unmarshal(bytes, &config); err != nil {
+		return nil, err
 	}
 
 	if err := config.Header.Finalize(); err != nil {
-		return err
+		return nil, err
 	}
 
-	return config.Deps.Finalize(file)
+	if err := config.Deps.Finalize(filename); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (config *V1) Headers() []*header.ConfigHeader {
+	return []*header.ConfigHeader{&config.Header}
+}
+
+func (config *V1) Dependencies() *deps.ConfigDeps {
+	return &config.Deps
+}
+
+type V2 struct {
+	Header []*header.ConfigHeader `yaml:"header"`
+	Deps   deps.ConfigDeps        `yaml:"dependency"`
+}
+
+func ParseV2(filename string, bytes []byte) (*V2, error) {
+	var config V2
+	if err := yaml.Unmarshal(bytes, &config); err != nil {
+		return nil, err
+	}
+
+	for _, header := range config.Header {
+		if err := header.Finalize(); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := config.Deps.Finalize(filename); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (config *V2) Headers() []*header.ConfigHeader {
+	return config.Header
+}
+
+func (config *V2) Dependencies() *deps.ConfigDeps {
+	return &config.Deps
+}
+
+type Config interface {
+	Headers() []*header.ConfigHeader
+	Dependencies() *deps.ConfigDeps
+}
+
+func NewConfigFromFile(filename string) (Config, error) {
+	var err error
+	var bytes []byte
+
+	// attempt to read configuration from specified file
+	logger.Log.Infoln("Loading configuration from file:", filename)
+
+	if bytes, err = os.ReadFile(filename); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if os.IsNotExist(err) {
+		logger.Log.Infof("Config file %s does not exist, using the default config", filename)
+
+		if bytes, err = assets.Asset("default-config.yaml"); err != nil {
+			return nil, err
+		}
+	}
+
+	var config Config
+	if config, err = ParseV2(filename, bytes); err == nil {
+		return config, nil
+	}
+	if config, err = ParseV1(filename, bytes); err != nil {
+		return nil, err
+	}
+	return config, nil
 }

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 func TestConfigHeaderSpdxASF(t *testing.T) {
-	c := config2.Config{}
-	if err := c.Parse("./testdata/test-spdx-asf.yaml"); err != nil {
+	var c config2.Config
+	var err error
+	if c, err = config2.NewConfigFromFile("./testdata/test-spdx-asf.yaml"); err != nil {
 		t.Error("unexpected error", err)
 	}
 
@@ -48,14 +49,15 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 `
-	if actual := c.Header.GetLicenseContent(); actual != expected {
+	if actual := c.Headers()[0].GetLicenseContent(); actual != expected {
 		t.Errorf("Actual: \n%v\nExpected: \n%v", actual, expected)
 	}
 }
 
 func TestConfigHeaderSpdxPlain(t *testing.T) {
-	c := config2.Config{}
-	if err := c.Parse("./testdata/test-spdx.yaml"); err != nil {
+	var c config2.Config
+	var err error
+	if c, err = config2.NewConfigFromFile("./testdata/test-spdx.yaml"); err != nil {
 		t.Error("unexpected error", err)
 	}
 
@@ -73,7 +75,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 `
-	if actual := c.Header.GetLicenseContent(); actual != expected {
+	if actual := c.Headers()[0].GetLicenseContent(); actual != expected {
 		t.Errorf("Actual: \n%v\nExpected: \n%v", actual, expected)
+	}
+}
+
+func TestConfigMultipleHeaders(t *testing.T) {
+	var c config2.Config
+	var err error
+	if c, err = config2.NewConfigFromFile("./testdata/test-multiple.yaml"); err != nil {
+		t.Error("unexpected error", err)
+	}
+	if len(c.Headers()) != 2 {
+		t.Errorf("Expected 2 header sections in the config. Actual %d", len(c.Headers()))
 	}
 }

--- a/test/testdata/multiple_license_test/pkg/a/main.go
+++ b/test/testdata/multiple_license_test/pkg/a/main.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2022 The Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main

--- a/test/testdata/multiple_license_test/pkg/a/main.go
+++ b/test/testdata/multiple_license_test/pkg/a/main.go
@@ -12,18 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright 2022 The Project Contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package main

--- a/test/testdata/multiple_license_test/pkg/b/main.go
+++ b/test/testdata/multiple_license_test/pkg/b/main.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main

--- a/test/testdata/multiple_license_test/pkg/b/main.go
+++ b/test/testdata/multiple_license_test/pkg/b/main.go
@@ -2,8 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 package main

--- a/test/testdata/test-multiple.yaml
+++ b/test/testdata/test-multiple.yaml
@@ -1,0 +1,14 @@
+header:
+  - license:
+      spdx-id: Apache-2.0
+      copyright-owner: The Project Contributors
+
+    paths:
+      - 'test/testdata/multiple_license_test/pkg/a'
+
+  - license:
+      spdx-id: MPL-2.0
+      copyright-owner: The Project Contributors
+
+    paths:
+      - 'test/testdata/multiple_license_test/pkg/b'


### PR DESCRIPTION
This allows for multiple `license` configurations to be contained
within the same .licenserc.yaml file. The intended use is for a project
that has multiple packages or modules with differing licenses.
   
To do this we introduce a ConfigV2 config format since it is not valid
YAML for a key to be either a dictionary or a sequence.
 
 We try to parse as V2 first, and fall back to V1.