### PR TITLE
Add subcommand support for github actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To use License-Eye in GitHub Actions, add a step in your GitHub workflow.
       # config: .licenserc.yaml # optional: set the config file. The default value is `.licenserc.yaml`.
       # token: # optional: the token that license eye uses when it needs to comment on the pull request. Set to empty ("") to disable commenting on pull request. The default value is ${{ github.token }}
       # mode: # optional: Which mode License-Eye should be run in. Choices are `check` or `fix`. The default value is `check`.
+      # subcommand: # optional: Which subcommand License Eye should be run in. Choices are `header` or `dependency`. The default value is `header`.
 ```
 
 Add a `.licenserc.yaml` in the root of your project, for Apache Software Foundation projects, the following configuration should be enough.

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,12 @@ inputs:
       default value is `check`.
     required: false
     default: check
+  subcommand:
+    description: |
+      Which subcommand License Eye should be run in. Choices are `header` or `dependency`. The
+      default value is `header`.
+    required: false
+    default: header
 runs:
   using: docker
   image: Dockerfile
@@ -51,5 +57,5 @@ runs:
     - ${{ inputs.log }}
     - -c
     - ${{ inputs.config }}
-    - header
+    - ${{ inputs.subcommand }}
     - ${{ inputs.mode }}


### PR DESCRIPTION
Usually CI not only needs to do `header check`, but also do `dep check`.

I added the `subcommand` argument to ensure compatibility, there may be a better way.