### PR TITLE
New Header Template: GPL-3.0-or-later

### DIFF
--- a/assets/header-templates/GPL-3.0-or-later.txt
+++ b/assets/header-templates/GPL-3.0-or-later.txt
@@ -1,0 +1,16 @@
+Copyright (C) [year] [owner]
+
+This file is part of [software-name].
+
+[software-name] is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+[software-name] is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/pkg/header/config.go
+++ b/pkg/header/config.go
@@ -196,9 +196,9 @@ func readLicenseFromSpdx(config *ConfigHeader) (string, error) {
 		return "", fmt.Errorf("failed to find a license template for spdx id %v, %w", spdxID, err)
 	}
 	template := string(content)
-	template = strings.Replace(template, "[year]", strconv.Itoa(time.Now().Year()), 1)
-	template = strings.Replace(template, "[owner]", owner, 1)
-	template = strings.Replace(template, "[software-name]", name, 1)
+	template = strings.ReplaceAll(template, "[year]", strconv.Itoa(time.Now().Year()))
+	template = strings.ReplaceAll(template, "[owner]", owner)
+	template = strings.ReplaceAll(template, "[software-name]", name)
 
 	return template, nil
 }


### PR DESCRIPTION
Created new header template for SPDX identifier `GPL-3.0-or-later`