### PR TITLE
Switch to npm ci for reliable builds

### DIFF
--- a/pkg/deps/npm.go
+++ b/pkg/deps/npm.go
@@ -127,7 +127,9 @@ func (resolver *NpmResolver) NeedSkipInstallPkgs() bool {
 	}
 }
 
-// InstallPkgs runs command 'npm install' to install node packages
+// InstallPkgs runs command 'npm ci' to install node packages,
+// using `npm ci` instead of `npm install` to ensure the reproducible builds.
+// See https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable
 func (resolver *NpmResolver) InstallPkgs() {
 	cmd := exec.Command("npm", "ci")
 	logger.Log.Println(fmt.Sprintf("Run command: %v, please wait", cmd.String()))

--- a/pkg/deps/npm.go
+++ b/pkg/deps/npm.go
@@ -129,7 +129,7 @@ func (resolver *NpmResolver) NeedSkipInstallPkgs() bool {
 
 // InstallPkgs runs command 'npm install' to install node packages
 func (resolver *NpmResolver) InstallPkgs() {
-	cmd := exec.Command("npm", "install")
+	cmd := exec.Command("npm", "ci")
 	logger.Log.Println(fmt.Sprintf("Run command: %v, please wait", cmd.String()))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
According to https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable, one should prefer `npm ci` over `npm install` for more reliable builds, so all the versions can be locked exactly unless we explicitly upgrade them.