### PR TITLE
Fix optional dependencies are not excluded

### DIFF
--- a/pkg/deps/maven.go
+++ b/pkg/deps/maven.go
@@ -320,7 +320,7 @@ func LoadDependenciesTree(data []byte) []*Dependency {
 	stack := []Elem{}
 	unique := make(map[string]struct{})
 
-	reFind := regexp.MustCompile(`(?im)^.*? ([| ]*)(\+-|\\-) (?P<gid>\b.+?):(?P<aid>\b.+?):(?P<packaging>\b.+)(:\b.+)?:(?P<version>\b.+):(?P<scope>\b.+?)$`) //nolint:lll // can't break down regex
+	reFind := regexp.MustCompile(`(?im)^.*? ([| ]*)(\+-|\\-) (?P<gid>\b.+?):(?P<aid>\b.+?):(?P<packaging>\b.+)(:\b.+)?:(?P<version>\b.+):(?P<scope>\b.+?)(?P<optional>\b.+?)?$`) //nolint:lll // can't break down regex
 	rawDeps := reFind.FindAllSubmatch(data, -1)
 
 	deps := make([]*Dependency, 0, len(rawDeps))

--- a/pkg/deps/maven_test.go
+++ b/pkg/deps/maven_test.go
@@ -49,7 +49,7 @@ func TestCanResolvePomFile(t *testing.T) {
 }
 
 func writeFile(fileName, content string) error {
-	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
+	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0777)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Optional dependencies should be excluded but they are not because of regexp missing the optional part


```
[INFO] +- org.mariadb.jdbc:mariadb-java-client:jar:2.7.2:provided (optional) 
```