### PR TITLE
dep: do not write license files if they already exist

### DIFF
--- a/commands/deps_resolve.go
+++ b/commands/deps_resolve.go
@@ -114,6 +114,10 @@ var DepsResolveCommand = &cobra.Command{
 func writeLicense(result *deps.Result) {
 	filename := string(fileNamePattern.ReplaceAll([]byte(result.Dependency), []byte("-")))
 	filename = filepath.Join(outDir, "license-"+filename+".txt")
+	if _, err := os.Stat(filename); err == nil {
+		logger.Log.Debug("File already exists, skipping: %s", filename)
+		return
+	}
 	file, err := os.Create(filename)
 	if err != nil {
 		logger.Log.Errorf("failed to create license file %v: %v", filename, err)

--- a/commands/deps_resolve.go
+++ b/commands/deps_resolve.go
@@ -115,7 +115,7 @@ func writeLicense(result *deps.Result) {
 	filename := string(fileNamePattern.ReplaceAll([]byte(result.Dependency), []byte("-")))
 	filename = filepath.Join(outDir, "license-"+filename+".txt")
 	if _, err := os.Stat(filename); err == nil {
-		logger.Log.Debug("File already exists, skipping: %s", filename)
+		logger.Log.Debugf("File already exists, skipping: %s", filename)
 		return
 	}
 	file, err := os.Create(filename)


### PR DESCRIPTION
Some dependencies can be identified and they are manually specified by `dependency.licenses`, in this case, the license file cannot be copied correctly, we have to again manually copy these license files but we don't want the license eye command to override these files.