### PR TITLE
fix license header normalizer

### DIFF
--- a/pkg/license/norm.go
+++ b/pkg/license/norm.go
@@ -233,12 +233,6 @@ var (
 			regexp.MustCompile(`(?m)\s+[*]$`),
 			" ",
 		},
-		// Copyright (c) .....
-		// © Copyright .....
-		{
-			regexp.MustCompile(`(?m)^\s*([cC©])?\s*Copyright (\([cC©]\))?.+$`),
-			"",
-		},
 		// Portions Copyright (C) ...
 		{
 			regexp.MustCompile(`(?m)^\s*Portions Copyright (\([cC©]\))?.+$`),


### PR DESCRIPTION
## Why do we need this fix?

As we are using `license-eyes` to check license header in our open-sourced projects, we notice that it can help detect 
unexpected changes in the license header, *except the copyright line*. In my opinion, it's also necessary to protect the copyright line from unintentional changes.

## How was this issue introduced?

https://github.com/apache/skywalking-eyes/pull/46 introduced this line processor to ignore copyright line, mostly for the purpose of dependency resolution. However, in https://github.com/apache/skywalking-eyes/pull/107 starts using Google's license check for this purpose, and this line processor only works to ignore copyright line when checking / fixing license header.

## Reviewer

@kezhenxu94 