### PR TITLE
dep/maven: use output file to store the dep tree for cleaner result

### DIFF
--- a/pkg/deps/golang.go
+++ b/pkg/deps/golang.go
@@ -85,7 +85,7 @@ func (resolver *GoModResolver) Resolve(goModFile string, config *ConfigDeps, rep
 func (resolver *GoModResolver) ResolvePackages(modules []*packages.Module, config *ConfigDeps, report *Report) error {
 	for _, module := range modules {
 		func() {
-			if exclued, _ := config.IsExcluded(module.Path, module.Version); exclued {
+			if excluded, _ := config.IsExcluded(module.Path, module.Version); excluded {
 				return
 			}
 			if l, ok := config.GetUserConfiguredLicense(module.Path, module.Version); ok {


### PR DESCRIPTION
When using output file to store the dependency tree, `dependency:tree` emits a cleaner tree with effective pom file, this reduces unused dependencies in result
