### PR TITLE
gha: switch to composite running mode and set up cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
 HUB ?= docker.io/apache
 PROJECT ?= license-eye
 VERSION ?= latest
+INSTALL_DIR ?= /usr/local/bin
 OUT_DIR = bin
 ARCH := $(shell uname)
 OSNAME := $(if $(findstring Darwin,$(ARCH)),darwin,linux)
@@ -28,6 +29,7 @@ GO_BUILD = $(GO) build
 GO_TEST = $(GO) test
 GO_LINT = $(GO_PATH)/bin/golangci-lint
 GO_BUILD_LDFLAGS = -X github.com/apache/skywalking-eyes/commands.version=$(VERSION)
+GOOS ?= $(shell $(GO) env GOOS)
 
 PLANTUML_VERSION = 1.2021.9
 
@@ -142,3 +144,11 @@ verify-docs: docs-gen
 		git diff --color --word-diff --exit-code docs; \
 		exit 1; \
 	fi
+
+.PHONY: install
+install: $(GOOS)
+	-cp $(OUT_DIR)/$(GOOS)/$(PROJECT) $(INSTALL_DIR)
+
+.PHONY: uninstall
+uninstall: $(GOOS)
+	-rm $(INSTALL_DIR)/$(PROJECT)

--- a/action.yml
+++ b/action.yml
@@ -42,14 +42,39 @@ inputs:
     required: false
     default: check
 runs:
-  using: docker
-  image: Dockerfile
-  env:
-    GITHUB_TOKEN: ${{ inputs.token }}
-  args:
-    - -v
-    - ${{ inputs.log }}
-    - -c
-    - ${{ inputs.config }}
-    - header
-    - ${{ inputs.mode }}
+  using: "composite"
+  steps:
+    - name: Set up Go 1.18
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+    - if: runner.os == 'Linux'
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: license-eye-${{ runner.os }}-go-${{ hashFiles(format('{0}/{1}', github.action_path, 'go.sum')) }}
+        restore-keys: license-eye-${{ runner.os }}-go-
+    - if: runner.os == 'macOS'
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/Library/Caches/go-build
+          ~/go/pkg/mod
+        key: license-eye-${{ runner.os }}-go-${{ hashFiles(format('{0}/{1}', github.action_path, 'go.sum')) }}
+        restore-keys: license-eye-${{ runner.os }}-go-
+    - if: runner.os == 'Windows'
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~\AppData\Local\go-build
+          ~\go\pkg\mod
+        key: license-eye-${{ runner.os }}-go-${{ hashFiles(format('{0}/{1}', github.action_path, 'go.sum')) }}
+        restore-keys: license-eye-${{ runner.os }}-go-
+    - shell: bash
+      run: make -C $GITHUB_ACTION_PATH install
+    - shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      run: license-eye -v ${{ inputs.log }} -c ${{ inputs.config }} header ${{ inputs.mode }}


### PR DESCRIPTION
This greatly shorten the waiting time;

- first run (~24s)

<img width="1688" alt="image" src="https://user-images.githubusercontent.com/15965696/221078401-2df04c07-74b0-4973-89c6-b5754a40f005.png">

- non first run (~4s)

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/15965696/221078268-f9eda3c2-15fc-40ff-ba5f-27a762c8c708.png">


Compared to previous Docker running mode

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/15965696/221078959-0c4e0da4-257c-42bd-ade7-d2749c771c45.png">
