### PR TITLE
Remove "portions copyright" header normalizer

### DIFF
--- a/pkg/license/norm.go
+++ b/pkg/license/norm.go
@@ -233,11 +233,6 @@ var (
 			regexp.MustCompile(`(?m)\s+[*]$`),
 			" ",
 		},
-		// Portions Copyright (C) ...
-		{
-			regexp.MustCompile(`(?m)^\s*Portions Copyright (\([cC©]\))?.+$`),
-			"",
-		},
 		// All rights reserved
 		{
 			regexp.MustCompile(`(?m)^\s*All rights reserved\.?$`),


### PR DESCRIPTION
Following up on the changes performed at https://github.com/apache/skywalking-eyes/pull/142, this PR is removing another regex that is causing the whole copyright line to be removed by the normalizer (due to the `.+$` match) if the line contains `Portions Copyright`.

 closes https://github.com/apache/skywalking/issues/11218

cc @kezhenxu94