### PR TITLE
update: add weak-compatible to dependency check

### DIFF
--- a/assets/compatibility/Apache-2.0.yaml
+++ b/assets/compatibility/Apache-2.0.yaml
@@ -90,5 +90,21 @@ incompatible:
   - NPL-1.0
   - NPL-1.1
 
-compatible-with-conditions:
+weak-compatible:
+  - CDDL-1.0
+  - CDDL-1.1
+  - CPL-1.0
+  - EPL-1.0
+  - EPL-2.0
+  - ErlPL-1.1
+  - IPA
+  - IPL-1.0
+  - LicenseRef-scancode-ubuntu-font-1.0
+  - LicenseRef-scancode-unrar
+  - MPL-1.0
+  - MPL-1.1
   - MPL-2.0
+  - OFL-1.1
+  - OSL-3.0
+  - Ruby
+  - SPL-1.0

--- a/assets/compatibility/Apache-2.0.yaml
+++ b/assets/compatibility/Apache-2.0.yaml
@@ -89,3 +89,6 @@ incompatible:
   - CPOL-1.02
   - NPL-1.0
   - NPL-1.1
+
+compatible-with-conditions:
+  - MPL-2.0

--- a/commands/deps_check.go
+++ b/commands/deps_check.go
@@ -29,7 +29,7 @@ import (
 var weakCompatible bool
 
 func init() {
-	DepsCheckCommand.PersistentFlags().BoolVarP(&weakCompatible, "weak-compatible", "w", false, "if set, include the weak-compatible list in dependencies checking")
+	DepsCheckCommand.PersistentFlags().BoolVarP(&weakCompatible, "weak-compatible", "w", false, "if set to true, treat the weak-compatible licenses as compatible in dependencies check. Note: when set to true, make sure to manually confirm that weak-compatible licenses are used under the required conditions.")
 }
 
 var DepsCheckCommand = &cobra.Command{

--- a/commands/deps_check.go
+++ b/commands/deps_check.go
@@ -29,7 +29,7 @@ import (
 var compatibleWithConditions bool
 
 func init() {
-	DepsCheckCommand.PersistentFlags().BoolVarP(&compatibleWithConditions, "compatible-with-conditions", "cc", false, "if set, include compatible-with-conditions list in dependencies checking")
+	DepsCheckCommand.PersistentFlags().BoolVar(&compatibleWithConditions, "compatible-with-conditions", false, "if set, include compatible-with-conditions list in dependencies checking")
 }
 
 var DepsCheckCommand = &cobra.Command{

--- a/commands/deps_check.go
+++ b/commands/deps_check.go
@@ -29,7 +29,10 @@ import (
 var weakCompatible bool
 
 func init() {
-	DepsCheckCommand.PersistentFlags().BoolVarP(&weakCompatible, "weak-compatible", "w", false, "if set to true, treat the weak-compatible licenses as compatible in dependencies check. Note: when set to true, make sure to manually confirm that weak-compatible licenses are used under the required conditions.")
+	DepsCheckCommand.PersistentFlags().BoolVarP(&weakCompatible, "weak-compatible", "w", false,
+		"if set to true, treat the weak-compatible licenses as compatible in dependencies check. "+
+			"Note: when set to true, make sure to manually confirm that weak-compatible licenses "+
+			"are used under the required conditions.")
 }
 
 var DepsCheckCommand = &cobra.Command{

--- a/commands/deps_check.go
+++ b/commands/deps_check.go
@@ -26,10 +26,10 @@ import (
 	"github.com/apache/skywalking-eyes/pkg/deps"
 )
 
-var compatibleWithConditions bool
+var weakCompatible bool
 
 func init() {
-	DepsCheckCommand.PersistentFlags().BoolVar(&compatibleWithConditions, "compatible-with-conditions", false, "if set, include compatible-with-conditions list in dependencies checking")
+	DepsCheckCommand.PersistentFlags().BoolVarP(&weakCompatible, "weak-compatible", "w", false, "if set, include the weak-compatible list in dependencies checking")
 }
 
 var DepsCheckCommand = &cobra.Command{
@@ -40,7 +40,7 @@ var DepsCheckCommand = &cobra.Command{
 		var errors []error
 		configDeps := Config.Dependencies()
 		for _, header := range Config.Headers() {
-			if err := deps.Check(header.License.SpdxID, configDeps, compatibleWithConditions); err != nil {
+			if err := deps.Check(header.License.SpdxID, configDeps, weakCompatible); err != nil {
 				errors = append(errors, err)
 			}
 		}

--- a/commands/deps_check.go
+++ b/commands/deps_check.go
@@ -26,6 +26,12 @@ import (
 	"github.com/apache/skywalking-eyes/pkg/deps"
 )
 
+var compatibleWithConditions bool
+
+func init() {
+	DepsCheckCommand.PersistentFlags().BoolVarP(&compatibleWithConditions, "compatible-with-conditions", "cc", false, "if set, include compatible-with-conditions list in dependencies checking")
+}
+
 var DepsCheckCommand = &cobra.Command{
 	Use:     "check",
 	Aliases: []string{"c"},
@@ -34,7 +40,7 @@ var DepsCheckCommand = &cobra.Command{
 		var errors []error
 		configDeps := Config.Dependencies()
 		for _, header := range Config.Headers() {
-			if err := deps.Check(header.License.SpdxID, configDeps); err != nil {
+			if err := deps.Check(header.License.SpdxID, configDeps, compatibleWithConditions); err != nil {
 				errors = append(errors, err)
 			}
 		}

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -106,6 +106,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 	for _, result := range append(report.Resolved, report.Skipped...) {
 		operator, spdxIDs := parseLicenseExpression(result.LicenseSpdxID)
 		fmt.Println("spdxIDs:", spdxIDs)
+		fmt.Println("result.LicenseSpdxID:", result.LicenseSpdxID)
 		fmt.Println("operator:", operator)
 		switch operator {
 		case LicenseOperatorAND:

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -105,7 +105,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 	var unknownResults []*Result
 	for _, result := range append(report.Resolved, report.Skipped...) {
 		operator, spdxIDs := parseLicenseExpression(result.LicenseSpdxID)
-		fmt.Printf("Result: %+v\n", result)
+		fmt.Println("spdxIDs:", spdxIDs)
 		fmt.Println("operator:", operator)
 		switch operator {
 		case LicenseOperatorAND:

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -134,7 +134,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 			}
 
 		default:
-			if compatible := compare(matrix.Compatible, spdxIDs[0]); compatible {
+			if compatible := compare(matrix.Compatible, spdxIDs[0]) || compare(matrix.CompatibleWithConditions, spdxIDs[0]); compatible {
 				continue
 			}
 			if incompatible := compare(matrix.Incompatible, spdxIDs[0]); incompatible {

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -105,7 +105,8 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 	var unknownResults []*Result
 	for _, result := range append(report.Resolved, report.Skipped...) {
 		operator, spdxIDs := parseLicenseExpression(result.LicenseSpdxID)
-
+		fmt.Printf("Result: %+v\n", result)
+		fmt.Println("operator:", operator)
 		switch operator {
 		case LicenseOperatorAND:
 			if compareAll(spdxIDs, func(spdxID string) bool {

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -100,6 +100,13 @@ func compareAny(spdxIDs []string, compare func(spdxID string) bool) bool {
 	return false
 }
 
+func compareCompatible(matrix *CompatibilityMatrix, spdxID string, weakCompatible bool) bool {
+	if weakCompatible {
+		return compare(matrix.Compatible, spdxID) || compare(matrix.WeakCompatible, spdxID)
+	}
+	return compare(matrix.Compatible, spdxID)
+}
+
 func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, report *Report, weakCompatible bool) error {
 	var incompatibleResults []*Result
 	var unknownResults []*Result
@@ -108,10 +115,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 		switch operator {
 		case LicenseOperatorAND:
 			if compareAll(spdxIDs, func(spdxID string) bool {
-				if weakCompatible {
-					return compare(matrix.Compatible, spdxID) || compare(matrix.WeakCompatible, spdxID)
-				}
-				return compare(matrix.Compatible, spdxID)
+				return compareCompatible(matrix, spdxID, weakCompatible)
 			}) {
 				continue
 			}
@@ -123,10 +127,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 
 		case LicenseOperatorOR:
 			if compareAny(spdxIDs, func(spdxID string) bool {
-				if weakCompatible {
-					return compare(matrix.Compatible, spdxID) || compare(matrix.WeakCompatible, spdxID)
-				}
-				return compare(matrix.Compatible, spdxID)
+				return compareCompatible(matrix, spdxID, weakCompatible)
 			}) {
 				continue
 			}

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -30,8 +30,9 @@ import (
 )
 
 type CompatibilityMatrix struct {
-	Compatible   []string `yaml:"compatible"`
-	Incompatible []string `yaml:"incompatible"`
+	Compatible               []string `yaml:"compatible"`
+	Incompatible             []string `yaml:"incompatible"`
+	CompatibleWithConditions []string `yaml:"compatible-with-conditions"`
 }
 
 var matrices = make(map[string]CompatibilityMatrix)
@@ -108,7 +109,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 		switch operator {
 		case LicenseOperatorAND:
 			if compareAll(spdxIDs, func(spdxID string) bool {
-				return compare(matrix.Compatible, spdxID)
+				return compare(matrix.Compatible, spdxID) || compare(matrix.CompatibleWithConditions, spdxID)
 			}) {
 				continue
 			}
@@ -120,7 +121,7 @@ func CheckWithMatrix(mainLicenseSpdxID string, matrix *CompatibilityMatrix, repo
 
 		case LicenseOperatorOR:
 			if compareAny(spdxIDs, func(spdxID string) bool {
-				return compare(matrix.Compatible, spdxID)
+				return compare(matrix.Compatible, spdxID) || compare(matrix.CompatibleWithConditions, spdxID)
 			}) {
 				continue
 			}

--- a/pkg/deps/check_test.go
+++ b/pkg/deps/check_test.go
@@ -53,7 +53,7 @@ var TestMatrix = deps.CompatibilityMatrix{
 		"GPL-2.0-only",
 		"GPL-2.0-or-later",
 	},
-	CompatibleWithConditions: []string{
+	WeakCompatible: []string{
 		"MPL-2.0",
 	},
 }

--- a/pkg/deps/check_test.go
+++ b/pkg/deps/check_test.go
@@ -158,7 +158,7 @@ func TestCheckWithMatrix(t *testing.T) {
 			},
 		},
 	}, false); err == nil {
-		t.Errorf("Should return error since compatibleWithConditions is turned off")
+		t.Errorf("Should return error since weak-compatible is turned off")
 	}
 
 	if err := deps.CheckWithMatrix("Apache-2.0", &TestMatrix, &deps.Report{


### PR DESCRIPTION
This PR is based on this discussion: https://github.com/apache/skywalking/discussions/11391.
A new list called `weak-compatible` is added to the [skywalking-eyes compatibility list](https://github.com/apache/skywalking-eyes/blob/main/assets/compatibility/Apache-2.0.yaml). 
A new flag called `weak-compatible` is added to the `dependency check` command.