### PR TITLE
add Eclipse Foundation specific Apache 2.0 license header

### DIFF
--- a/assets/header-templates/Apache-2.0-EF.txt
+++ b/assets/header-templates/Apache-2.0-EF.txt
@@ -1,0 +1,7 @@
+Copyright (c) [year] [owner]
+
+This program and the accompanying materials are made
+available under the terms of the Apache Software License 2.0
+which is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
As per the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#ip-copyright-headers)