### PR TITLE
bump action/setup-go to v5

### DIFF
--- a/.github/workflows/license-eye-check.yaml
+++ b/.github/workflows/license-eye-check.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.18
 

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go 1.18
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.18
         cache-dependency-path: ${{ github.action_path }}/go.sum

--- a/dependency/action.yml
+++ b/dependency/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go 1.18
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.18
         cache-dependency-path: ${{ github.action_path }}/go.sum

--- a/header/action.yml
+++ b/header/action.yml
@@ -45,7 +45,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go 1.18
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.18
         cache-dependency-path: ${{ github.action_path }}/go.sum


### PR DESCRIPTION
fixes the following warning:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.