### PR TITLE
Bump up to go 1.23 and clean up Docker images

### DIFF
--- a/.github/workflows/license-eye-check.yaml
+++ b/.github/workflows/license-eye-check.yaml
@@ -28,11 +28,11 @@ jobs:
     name: Build LicenseEye
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.23
 
       - name: Lint Codes
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,10 +33,11 @@ linters-settings:
     min-len: 2
     min-occurrences: 2
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-messages:
-      fmt: "logging is allowed only by logutils.Log"
+    rules:
+      main:
+        deny:
+          - pkg: "fmt"
+            desc: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
     ignore-words:
@@ -94,11 +95,9 @@ linters-settings:
 linters:
   enable:
     - bodyclose
-    - deadcode
-    - depguard
+    - errcheck
     - dogsled
     - dupl
-    - errcheck
     - funlen
     - goconst
     - gocritic
@@ -114,16 +113,13 @@ linters:
     - misspell
     - nakedret
     - staticcheck
-    - structcheck
-    - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 service:
-  golangci-lint-version: 1.20.x
+  golangci-lint-version: 1.63.4
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ RELEASE_SRC = skywalking-$(PROJECT)-$(VERSION)-src
 all: clean lint license test build
 
 $(GO_LINT):
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin v1.49.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_PATH)/bin v1.63.4
 
 .PHONY: lint
 lint: $(GO_LINT)
@@ -74,7 +74,7 @@ build: windows linux darwin
 
 .PHONY: docker
 docker:
-	docker build . -t $(HUB)/$(PROJECT):$(VERSION) -t $(HUB)/$(PROJECT):latest
+	docker build --no-cache . -t $(HUB)/$(PROJECT):$(VERSION) -t $(HUB)/$(PROJECT):latest
 
 .PHONY: docker-push
 docker-push:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ docker run -it --rm -v $(pwd):/github/workspace apache/skywalking-eyes header ch
 docker run -it --rm -v $(pwd):/github/workspace apache/skywalking-eyes header fix
 ```
 
+#### Using Docker for License Dependency Checks
+
+To check dependencies' licenses in Docker, you'll need the appropriate language runtime and package managers in your environment. The base Docker image only includes the license-eye binary. To check dependencies, you can build a custom Docker image with your required language tools:
+
+```dockerfile
+FROM apache/skywalking-eyes:latest
+
+# Install the tools you need
+```
+
+See the [examples directory](examples/) for more detailed examples and Dockerfiles for different languages.
+
 ### Docker Image from the latest codes
 
 For users and developers who want to help to test the latest codes on main branch, we publish a Docker image to the GitHub

--- a/action.yml
+++ b/action.yml
@@ -44,10 +44,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Go 1.18
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.23
         cache-dependency-path: ${{ github.action_path }}/go.sum
     - shell: bash
       run: make -C $GITHUB_ACTION_PATH install

--- a/commands/deps_check.go
+++ b/commands/deps_check.go
@@ -39,7 +39,7 @@ var DepsCheckCommand = &cobra.Command{
 	Use:     "check",
 	Aliases: []string{"c"},
 	Long:    "resolves and check license compatibility in all dependencies of a module and their transitive dependencies",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		var errors []error
 		configDeps := Config.Dependencies()
 		for _, header := range Config.Headers() {

--- a/commands/deps_resolve.go
+++ b/commands/deps_resolve.go
@@ -33,10 +33,12 @@ import (
 	"github.com/apache/skywalking-eyes/pkg/deps"
 )
 
-var outDir string
-var licensePath string
-var summaryTplPath string
-var summaryTpl *template.Template
+var (
+	outDir         string
+	licensePath    string
+	summaryTplPath string
+	summaryTpl     *template.Template
+)
 
 func init() {
 	DepsResolveCommand.PersistentFlags().StringVarP(&outDir, "output", "o", "",
@@ -54,7 +56,7 @@ var DepsResolveCommand = &cobra.Command{
 	Use:     "resolve",
 	Aliases: []string{"r"},
 	Long:    "resolves all dependencies of a module and their transitive dependencies",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(_ *cobra.Command, _ []string) error {
 		if outDir != "" {
 			absPath, err := filepath.Abs(outDir)
 			if err != nil {
@@ -97,7 +99,7 @@ var DepsResolveCommand = &cobra.Command{
 		}
 		return nil
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		report := deps.Report{}
 
 		configDeps := Config.Dependencies()

--- a/commands/header_check.go
+++ b/commands/header_check.go
@@ -32,7 +32,7 @@ var CheckCommand = &cobra.Command{
 	Use:     "check",
 	Aliases: []string{"c"},
 	Long:    "check command walks the specified paths recursively and checks if the specified files have the license header in the config file.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		hasErrors := false
 		for _, h := range Config.Headers() {
 			var result header.Result

--- a/commands/header_fix.go
+++ b/commands/header_fix.go
@@ -31,7 +31,7 @@ var FixCommand = &cobra.Command{
 	Use:     "fix",
 	Aliases: []string{"f"},
 	Long:    "fix command walks the specified paths recursively and fix the license header if the specified files don't have the license header.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		var errors []string
 		for _, h := range Config.Headers() {
 			var result header.Result

--- a/commands/root.go
+++ b/commands/root.go
@@ -37,7 +37,7 @@ var root = &cobra.Command{
 	Long:          "A full-featured license guard to check and fix license headers and dependencies' licenses",
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		level, err := logrus.ParseLevel(verbosity)
 		if err != nil {
 			return err

--- a/dependency/action.yml
+++ b/dependency/action.yml
@@ -42,10 +42,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Go 1.18
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.23
         cache-dependency-path: ${{ github.action_path }}/go.sum
     - shell: bash
       run: make -C $GITHUB_ACTION_PATH/.. install

--- a/examples/golang/Dockerfile
+++ b/examples/golang/Dockerfile
@@ -15,18 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.23-alpine AS build
+FROM apache/skywalking-eyes:latest
 
-WORKDIR /license-eye
+ARG GO_VERSION=1.23.1
+ARG TARGETARCH
 
-COPY . .
+# Install Go
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz \
+    && tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz \
+    && rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 
-RUN apk add --no-cache make curl && make linux
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GOPATH=/go
+ENV PATH=$PATH:$GOPATH/bin
 
-FROM alpine:3 AS bin
-
-COPY --from=build /license-eye/bin/linux/license-eye /bin/license-eye
-
-WORKDIR /github/workspace/
-
-ENTRYPOINT ["/bin/license-eye"]
+WORKDIR /github/workspace 

--- a/examples/java/Dockerfile
+++ b/examples/java/Dockerfile
@@ -15,18 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.23-alpine AS build
+FROM apache/skywalking-eyes:latest
 
-WORKDIR /license-eye
+ARG JAVA_VERSION=17
+ARG TARGETARCH
 
-COPY . .
+# Install OpenJDK
+RUN apk add --no-cache --update openjdk${JAVA_VERSION}-jdk
 
-RUN apk add --no-cache make curl && make linux
+ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk-${TARGETARCH}
+ENV PATH=$PATH:$JAVA_HOME/bin
 
-FROM alpine:3 AS bin
-
-COPY --from=build /license-eye/bin/linux/license-eye /bin/license-eye
-
-WORKDIR /github/workspace/
-
-ENTRYPOINT ["/bin/license-eye"]
+WORKDIR /github/workspace 

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -15,18 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.23-alpine AS build
+FROM apache/skywalking-eyes:latest
 
-WORKDIR /license-eye
+ARG NODE_VERSION=22.13.1
+ARG TARGETARCH
 
-COPY . .
+# Install Node.js
+RUN apk add --no-cache --update nodejs=${NODE_VERSION}-r0 npm
 
-RUN apk add --no-cache make curl && make linux
-
-FROM alpine:3 AS bin
-
-COPY --from=build /license-eye/bin/linux/license-eye /bin/license-eye
-
-WORKDIR /github/workspace/
-
-ENTRYPOINT ["/bin/license-eye"]
+WORKDIR /github/workspace 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-eyes
 
-go 1.18
+go 1.23
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/header/action.yml
+++ b/header/action.yml
@@ -44,10 +44,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Go 1.18
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.23
         cache-dependency-path: ${{ github.action_path }}/go.sum
     - shell: bash
       run: make -C $GITHUB_ACTION_PATH/.. install

--- a/pkg/deps/jar.go
+++ b/pkg/deps/jar.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -126,7 +127,12 @@ func (resolver *JarResolver) ReadFileFromZip(archiveFile *zip.File) (*bytes.Buff
 
 	buf := bytes.NewBuffer(nil)
 	w := bufio.NewWriter(buf)
-	_, err = io.CopyN(w, file, int64(archiveFile.UncompressedSize64))
+
+	size := archiveFile.UncompressedSize64
+	if size > math.MaxInt64 {
+		return nil, fmt.Errorf("file too large: size %d exceeds maximum supported size", size)
+	}
+	_, err = io.CopyN(w, file, int64(size))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deps/maven.go
+++ b/pkg/deps/maven.go
@@ -21,7 +21,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -125,7 +124,7 @@ func (resolver *MavenPomResolver) ResolveDeps() error {
 }
 
 func (resolver *MavenPomResolver) LoadDependencies(config *ConfigDeps) ([]*Dependency, error) {
-	depsFile, err := ioutil.TempFile(os.TempDir(), "maven-dependencies.txt")
+	depsFile, err := os.CreateTemp(os.TempDir(), "maven-dependencies.txt")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/header/check.go
+++ b/pkg/header/check.go
@@ -142,7 +142,7 @@ func walkFile(file string, seen map[string]bool) ([]string, error) {
 		case mode.IsRegular():
 			files = append(files, file)
 		case mode.IsDir():
-			err := filepath.Walk(file, func(path string, info fs.FileInfo, err error) error {
+			err := filepath.Walk(file, func(path string, info fs.FileInfo, _ error) error {
 				if path == file {
 					// when path is symbolic link file, it causes infinite recursive calls
 					return nil


### PR DESCRIPTION
Dependencies license check depends on different programming language env and version, it’s unreasonable to include the env in the Docker image by default, this PR cleans the programming language tools from the Docker images to reduce the size from 350+M to ~36M