### PR TITLE
Record the use of SkyWalking Eyes Docker Image under PowerShell 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,18 @@ To check dependencies license in GitHub Actions, add a step in your GitHub workf
 
 ### Docker Image
 
+For Bash, users can execute the following command,
+
 ```shell
 docker run -it --rm -v $(pwd):/github/workspace apache/skywalking-eyes header check
 docker run -it --rm -v $(pwd):/github/workspace apache/skywalking-eyes header fix
+```
+
+For PowerShell 7, users can execute the following command,
+
+```
+docker run -it --rm -v ${pwd}:/github/workspace apache/skywalking-eyes header check
+docker run -it --rm -v ${pwd}:/github/workspace apache/skywalking-eyes header fix
 ```
 
 #### Using Docker for License Dependency Checks


### PR DESCRIPTION
- Record the use of SkyWalking Eyes Docker Image under PowerShell 7.
- This is a discovery from https://github.com/linghengqian/hive-server2-jdbc-driver/pull/28 . `$(pwd)` is not available under PowerShell 7, and I think proper documentation will help Windows 11 users.