### PR TITLE
Add few missing compatible licenses for dependency check

### DIFF
--- a/assets/compatibility/Apache-2.0.yaml
+++ b/assets/compatibility/Apache-2.0.yaml
@@ -20,6 +20,7 @@
 compatible:
   - Apache-2.0
   - PHP-3.01
+  - 0BSD
   - BSD-3-Clause
   - BSD-2-Clause
   - BSD-2-Clause-Views

--- a/assets/compatibility/Apache-2.0.yaml
+++ b/assets/compatibility/Apache-2.0.yaml
@@ -24,7 +24,7 @@ compatible:
   - BSD-2-Clause
   - BSD-2-Clause-Views
   - PostgreSQL
-  - EPL-1.0
+  - EDL-1.0
   - ISC
   - SMLNJ
   - ICU.txt
@@ -45,6 +45,7 @@ compatible:
   - HPND.txt
   - MulanPSL-2.0.txt
   - MIT
+  - MIT-0
 
 incompatible:
   - Unknown


### PR DESCRIPTION
I found that EPL-1.0 appears in both the "compatible" and "weak-compatible" lists. Perhaps what we intended to write in the "compatible" list was EDL-1.0 (Eclipse Distribution License 1.0)? 
Also, add MIT-0 (MIT No Attribution) and 0BSD (Zero-Clause BSD) to the "compatible" list.