### PR TITLE
Update example workflow in the README for the Ruby scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ jobs:
         uses: apache/skywalking-eyes/dependency@main
         with:
           config: .licenserc.yaml
+          # Ruby packages declared as dependencies in gemspecs or Gemfiles are
+          #   typically consumed as binaries; enable weak-compatibility
+          #   so permissive and weak-copyleft combinations are treated as compatible.
+          flags: --weak-compatible
 ```
 
 Note: License-Eye may query the RubyGems API to determine licenses when they are not specified in your configuration. Ensure the workflow has network access.

--- a/README.md
+++ b/README.md
@@ -127,10 +127,42 @@ dependency:
 GitHub Actions example:
 
 ```yaml
-- name: Check Ruby dependencies' licenses
-  uses: apache/skywalking-eyes/dependency@main
-  with:
-    config: .licenserc.yaml
+name: Apache SkyWalking Eyes
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'main'
+      - '*-stable'
+    tags:
+      - '!*' # Do not execute on tags
+  pull_request:
+    branches:
+      - '*'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  license-check:
+    if: "!contains(github.event.commits[0].message, '[ci skip]') && !contains(github.event.commits[0].message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check Dependencies' License
+        uses: apache/skywalking-eyes/dependency@main
+        with:
+          config: .licenserc.yaml
 ```
 
 Note: License-Eye may query the RubyGems API to determine licenses when they are not specified in your configuration. Ensure the workflow has network access.


### PR DESCRIPTION
Allow weak-compatible for Ruby
- Ruby packages declared as dependencies in gemspecs or Gemfiles are typically consumed as binaries; 
- enable weak-compatibility so permissive and weak-copyleft combinations are treated as compatible

NOTE: I've blogged about how to set up a Ruby project specifically, but it is broadly applicable:
https://dev.to/galtzo/how-to-check-license-compatibility-41h0