### PR TITLE
fix: corrrect RoundBracketAsterisk comment style

### DIFF
--- a/assets/styles.yaml
+++ b/assets/styles.yaml
@@ -41,8 +41,8 @@
 
 - id: RoundBracketAsterisk
   start: '(*'
-  middle: '(*'
-  end: '(*'
+  middle: ' *'
+  end: ' *)'
 
 - id: CurlyBracketDash
   start: '{-'

--- a/pkg/header/fix_test.go
+++ b/pkg/header/fix_test.go
@@ -84,9 +84,11 @@ func TestRewriteContent(t *testing.T) {
 			content: `print_string "hello worlds!\n";;
 `,
 			licenseHeader: getLicenseHeader("test.ml", t.Error),
-			expectedContent: `(* Apache License 2.0
-(*   http://www.apache.org/licenses/LICENSE-2.0
-(* Apache License 2.0
+			expectedContent: `(*
+ * Apache License 2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Apache License 2.0
+ *)
 
 print_string "hello worlds!\n";;
 `},

--- a/test/testdata/include_test/with_license/testcase.ml
+++ b/test/testdata/include_test/with_license/testcase.ml
@@ -1,18 +1,20 @@
-(* Licensed to the Apache Software Foundation (ASF) under one
-(* or more contributor license agreements.  See the NOTICE file
-(* distributed with this work for additional information
-(* regarding copyright ownership.  The ASF licenses this file
-(* to you under the Apache License, Version 2.0 (the
-(* "License"); you may not use this file except in compliance
-(* with the License.  You may obtain a copy of the License at
 (*
-(*   http://www.apache.org/licenses/LICENSE-2.0
-(*
-(* Unless required by applicable law or agreed to in writing,
-(* software distributed under the License is distributed on an
-(* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-(* KIND, either express or implied.  See the License for the
-(* specific language governing permissions and limitations
-(* under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *)
 
 let to_string = function Left -> "Left" | Non -> "Non" | Right -> "Right"

--- a/test/testdata/spdx_content_test/testcase.ml
+++ b/test/testdata/spdx_content_test/testcase.ml
@@ -1,3 +1,5 @@
-(* SPDX-License-Identifier: Apache-2.0
+(*
+ * SPDX-License-Identifier: Apache-2.0
+ *)
 
 let to_string = function Left -> "Left" | Non -> "Non" | Right -> "Right"


### PR DESCRIPTION
Correct the comment style used by `RoundBracketAsterisk` in the `OCaml` language.

For the file `main.ml` with the contents:

```ocaml
let () = print_endline "Hello, World!"
```

<details><summary>Current comment style </summary>

```ocaml
(* Licensed to the Apache Software Foundation (ASF) under one
(* or more contributor license agreements.  See the NOTICE file
(* distributed with this work for additional information
(* regarding copyright ownership.  The ASF licenses this file
(* to you under the Apache License, Version 2.0 (the
(* "License"); you may not use this file except in compliance
(* with the License.  You may obtain a copy of the License at
(*
(*   http://www.apache.org/licenses/LICENSE-2.0
(*
(* Unless required by applicable law or agreed to in writing,
(* software distributed under the License is distributed on an
(* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
(* KIND, either express or implied.  See the License for the
(* specific language governing permissions and limitations
(* under the License.

let () = print_endline "Hello, World!"
```

</details>

<details><summary>Corrected comment style</summary>

```ocaml
(*
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
 * regarding copyright ownership.  The ASF licenses this file
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
 *)

let () = print_endline "Hello, World!"
```

</details>


