### PR TITLE
fix: don't treat mid-file #! strings as Python shebangs

### DIFF
--- a/assets/styles.yaml
+++ b/assets/styles.yaml
@@ -116,7 +116,7 @@
 
 - id: PythonDocStringStyle
   # (interpreter binary and encoding comment) | (only interpreter binary) | (only encoding comment)
-  after: '(?m)(^#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(^#!.+$)|(^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
+  after: '(?m)(\A#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(\A#!.+$)|(\A[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
   start: '"""'
   middle: ~
   end: '"""'

--- a/assets/styles.yaml
+++ b/assets/styles.yaml
@@ -21,7 +21,7 @@
   end: '//'
 
 - id: Hashtag
-  after: '(?m)^*#!.+$'
+  after: '(?m)\A#!.+$'
   start: '#'
   middle: '#'
   end: '#'

--- a/assets/styles.yaml
+++ b/assets/styles.yaml
@@ -109,7 +109,7 @@
 
 - id: PythonStyle
   # (interpreter binary and encoding comment) | (only interpreter binary) | (only encoding comment)
-  after: '(?m)(^#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(^#!.+$)|(^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
+  after: '(?m)(\A#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(\A#!.+$)|(\A[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
   start: '#'
   middle: '#'
   end: '#'

--- a/assets/styles.yaml
+++ b/assets/styles.yaml
@@ -109,14 +109,14 @@
 
 - id: PythonStyle
   # (interpreter binary and encoding comment) | (only interpreter binary) | (only encoding comment)
-  after: '(?m)(^*#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(^*#!.+$)|(^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
+  after: '(?m)(^#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(^#!.+$)|(^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
   start: '#'
   middle: '#'
   end: '#'
 
 - id: PythonDocStringStyle
   # (interpreter binary and encoding comment) | (only interpreter binary) | (only encoding comment)
-  after: '(?m)(^*#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(^*#!.+$)|(^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
+  after: '(?m)(^#!.+$\n^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)|(^#!.+$)|(^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+).*$)'
   start: '"""'
   middle: ~
   end: '"""'

--- a/pkg/header/fix_test.go
+++ b/pkg/header/fix_test.go
@@ -215,6 +215,46 @@ EOF
 }
 `},
 		{
+			name:  "Bash with shebang-like string mid file",
+			style: comments.FileCommentStyle("test.sh"),
+			content: `generate_script() {
+  SCRIPT='#!/bin/bash
+echo "Hello, World!"'
+  echo "$SCRIPT"
+}
+`,
+			licenseHeader: getLicenseHeader("test.sh", t.Error),
+			expectedContent: `# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+generate_script() {
+  SCRIPT='#!/bin/bash
+echo "Hello, World!"'
+  echo "$SCRIPT"
+}
+`},
+		{
+			name:  "Python with encoding mid file",
+			style: comments.FileCommentStyle("test.py"),
+			content: `x = 1
+
+# -*- coding: utf-8 -*-
+if __name__ == '__main__':
+    print('Hello World')
+`,
+			licenseHeader: getLicenseHeader("test.py", t.Error),
+			expectedContent: `# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+x = 1
+
+# -*- coding: utf-8 -*-
+if __name__ == '__main__':
+    print('Hello World')
+`},
+		{
 			name:  "Python with interpreter binary and encoding",
 			style: comments.FileCommentStyle("test.py"),
 			content: `#!/usr/bin/env python3
@@ -483,6 +523,28 @@ end
 # Apache License 2.0
 
 class Example
+end
+`,
+		}, {
+			name:  "Ruby with shebang-like string mid file",
+			style: comments.FileCommentStyle("test.rb"),
+			content: `class Example
+  SCRIPT = <<~RUBY
+    #!/usr/bin/env ruby
+    puts "Hello, World!"
+  RUBY
+end
+`,
+			licenseHeader: getLicenseHeader("test.rb", t.Error),
+			expectedContent: `# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+class Example
+  SCRIPT = <<~RUBY
+    #!/usr/bin/env ruby
+    puts "Hello, World!"
+  RUBY
 end
 `,
 		}, {

--- a/pkg/header/fix_test.go
+++ b/pkg/header/fix_test.go
@@ -135,6 +135,48 @@ if __name__ == '__main__':
     print('Hello World')
 `},
 		{
+			name:  "Python with shebang-like string mid file",
+			style: comments.FileCommentStyle("test.py"),
+			content: `def some_function():
+    print(
+        """#!/usr/bin/env python3
+        print("Hello, World!")
+        """)
+`,
+			licenseHeader: getLicenseHeader("test.py", t.Error),
+			expectedContent: `# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+def some_function():
+    print(
+        """#!/usr/bin/env python3
+        print("Hello, World!")
+        """)
+`},
+		{
+			name:  "Python with shebang and shebang-like string mid file",
+			style: comments.FileCommentStyle("test.py"),
+			content: `#!/usr/bin/env python3
+def some_function():
+    print(
+        """#!/usr/bin/env python3
+        print("Hello, World!")
+        """)
+`,
+			licenseHeader: getLicenseHeader("test.py", t.Error),
+			expectedContent: `#!/usr/bin/env python3
+# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+def some_function():
+    print(
+        """#!/usr/bin/env python3
+        print("Hello, World!")
+        """)
+`},
+		{
 			name:  "Python with interpreter binary and encoding",
 			style: comments.FileCommentStyle("test.py"),
 			content: `#!/usr/bin/env python3

--- a/pkg/header/fix_test.go
+++ b/pkg/header/fix_test.go
@@ -177,6 +177,44 @@ def some_function():
         """)
 `},
 		{
+			name:  "Python with column-0 shebang-like string mid file",
+			style: comments.FileCommentStyle("test.py"),
+			content: `x = """
+#!/usr/bin/env python3
+hello
+"""
+`,
+			licenseHeader: getLicenseHeader("test.py", t.Error),
+			expectedContent: `# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+x = """
+#!/usr/bin/env python3
+hello
+"""
+`},
+		{
+			name:  "Shell with column-0 shebang-like string mid file",
+			style: comments.FileCommentStyle("test.sh"),
+			content: `foo() {
+  cat <<EOF
+#!/bin/bash is just text
+EOF
+}
+`,
+			licenseHeader: getLicenseHeader("test.sh", t.Error),
+			expectedContent: `# Apache License 2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Apache License 2.0
+
+foo() {
+  cat <<EOF
+#!/bin/bash is just text
+EOF
+}
+`},
+		{
 			name:  "Python with interpreter binary and encoding",
 			style: comments.FileCommentStyle("test.py"),
 			content: `#!/usr/bin/env python3


### PR DESCRIPTION
## Summary
- The Python comment-style `after` pattern used `^*#!`, which could match `#!` mid-line (e.g. inside a string), so `header fix` inserted the license in the wrong place.
- Anchor shebang matches to the start of a line (`^#!`) in `PythonStyle` / `PythonDocStringStyle`.
- Add rewrite unit tests for a mid-file shebang-like string, with and without a real first-line shebang.

### Example
Before this fix, `header fix` could insert the license after a shebang-like string in the middle of the file:

```python
def some_function():
    print(
        """#!/usr/bin/env python3
        print("Hello, World!")
        """)
```

became something like:

```python
def some_function():
    print(
        """#!/usr/bin/env python3
# Licensed to the Apache Software Foundation (ASF) under one
# ...
        print("Hello, World!")
        """)
```

Now the license is inserted at the top of the file (or after a real first-line shebang, when present).