### PR TITLE
fix: pin docker/login-action to an ASF-approved commit SHA

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
       - name: Log in to the Container registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}


### PR DESCRIPTION
### Problem

The `publish-docker` workflow has been failing on every push to `main` with
`startup_failure` — no jobs ever start, so there is no job log to inspect:

https://github.com/apache/skywalking-eyes/actions/runs/30420520851

### Cause

`.github/workflows/publish-docker.yaml` referenced a third-party action by
version tag:

```yaml
uses: docker/login-action@v1.10.0
```

The [ASF GitHub Actions policy](https://infra.apache.org/github-actions-policy.html)
requires every third-party action to be pinned to a reviewed **commit SHA** listed in
[`apache/infrastructure-actions/approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml).
Only the `actions/*`, `apache/*` and `github/*` namespaces are exempt — which is why
`lint.yaml` and `license-eye-check.yaml` are unaffected. A tag reference is rejected
before the run starts, hence the startup failure.

This was the only unpinned third-party action left in the repo.

### Fix

Pin to `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` (`v4.2.0`), which is on the approved
list and is already the pin used by `skywalking`, `skywalking-java`, `skywalking-cli`,
`skywalking-go`, `skywalking-python`, `skywalking-horizon-ui` and `skywalking-showcase`.

The v1 → v4 bump is safe for this step: `skywalking-cli` runs the identical step shape
on this exact pin — same `registry: ${{ env.HUB }}` (a value carrying a path,
`ghcr.io/apache/...`), same `github.actor` / `GITHUB_TOKEN` credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)